### PR TITLE
remove constant factor from Warren_2020 model

### DIFF
--- a/python/snewpy/models.py
+++ b/python/snewpy/models.py
@@ -877,7 +877,8 @@ class Zha_2021(SupernovaModel):
 
 
 class Warren_2020(SupernovaModel):
-    """Set up a model based on simulations from Warren et al. (2020)."""
+    """Set up a model based on simulations from Warren et al., ApJ 898:139, 2020.
+    Neutrino fluxes available at https://doi.org/10.5281/zenodo.3667908."""
 
     def __init__(self, filename, eos='LS220'):
         """Initialize model.
@@ -901,7 +902,7 @@ class Warren_2020(SupernovaModel):
         simtab['TIME'] = f['nue_data']['lum'][:, 0] - bounce
         simtab['L_NU_E'] = f['nue_data']['lum'][:, 1] * 1e51
         simtab['L_NU_E_BAR'] = f['nuae_data']['lum'][:, 1] * 1e51
-        simtab['L_NU_X'] = f['nux_data']['lum'][:, 1] * 1e51 / 4.0
+        simtab['L_NU_X'] = f['nux_data']['lum'][:, 1] * 1e51
         simtab['E_NU_E'] = f['nue_data']['avg_energy'][:, 1]
         simtab['E_NU_E_BAR'] = f['nuae_data']['avg_energy'][:, 1]
         simtab['E_NU_X'] = f['nux_data']['avg_energy'][:, 1]


### PR DESCRIPTION
> Note that the x neutrino luminosity is for **one** neutrino flavor - to get the total mu/tau neutrino and antineutrino luminosities requires multiplying this number by 4.

(from https://doi.org/10.5281/zenodo.3667908)

Accordingly, the nu_x luminosity should not be divided by 4 when reading in data from these files. This PR removes that factor and, while I’m at it, adds the journal reference and the DOI link for the neutrino fluxes.