### PR TITLE
set long_description_content_type for README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup_keywords['long_description'] = ''
 if os.path.exists('README.md'):
     with open('README.md') as readme:
         setup_keywords['long_description'] = readme.read()
+    setup_keywords['long_description_content_type'] = 'text/markdown'
 #
 # Set other keywords for the setup function.
 #


### PR DESCRIPTION
Will render poorly on PyPI otherwise; see https://test.pypi.org/project/snewpy/0.1.0.dev2/ and https://packaging.python.org/specifications/core-metadata/#description-content-type-optional