### PR TITLE
Add documentation content

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../../python/'))
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -30,6 +30,16 @@ By default, they will be downloaded to a subdirectory named ``SNEWPY-models/<mod
    (e.g. DOI or arXiv identifier). If you use one of these models, please always cite the appropriate reference.
 
 
+Usage
+-----
+
+.. warning::
+
+   Include a few simple usage examples here, e.g. some basic plots for one model.
+   Refer to Jupyter notebooks in ``doc/nb/`` for more usage examples.
+
+More advanced usage of SNEWPy requires SNOwGLoBES.
+
 Download Additional Dependencies
 --------------------------------
 Important parts of SNEWPy’s functionality require the `SNOwGLoBES <https://github.com/SNOwGLoBES/snowglobes>`_ and

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -38,14 +38,4 @@ Usage
    Include a few simple usage examples here, e.g. some basic plots for one model.
    Refer to Jupyter notebooks in ``doc/nb/`` for more usage examples.
 
-More advanced usage of SNEWPy requires SNOwGLoBES.
-
-Download Additional Dependencies
---------------------------------
-Important parts of SNEWPy’s functionality require the `SNOwGLoBES <https://github.com/SNOwGLoBES/snowglobes>`_ and
-`GLoBES <https://www.mpi-hd.mpg.de/personalhomes/globes/>`_ libraries, which need to be installed separately.
-
-.. warning::
-
-   Should we include installation instructions for those here? (E.g. copied from the README)
-   Or is it better to refer to their respective documentation for that?
+More advanced usage of SNEWPy requires SNOwGLoBES and is described in the following section.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
    
    gettingstarted
+   snowglobes
    models
    transformations
    neutrino

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,6 +12,9 @@ Contents:
    :maxdepth: 2
    
    gettingstarted
+   models
+   transformations
+   neutrino
 
 
 Indices and tables

--- a/doc/source/models.rst
+++ b/doc/source/models.rst
@@ -1,0 +1,18 @@
+Supernova Models: ``snewpy.models``
+===================================
+
+.. warning::
+
+   This was automatically generated from docstrings in ``models.py`` and still needs some editing.
+   See `the autodoc configuration <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_ for help.
+
+   In particular:
+
+   * The base class ``snewpy.models.SupernovaModel`` should be at the top of the page and highlighted
+   * ``get_time`` and ``get_initialspectra`` have the same signature for most models (apart from the additional interpolation parameter for the ``Fornax`` models); avoid repetitive documentation?
+   * Purely internal functions (e.g. in the ``Fornax`` models) should not appear here.
+   * Should ``Tamborra_2014`` and ``Walk_201x`` get a docstring explaining that they are aliases for ``Bollig_2016``?
+
+
+.. automodule:: snewpy.models
+   :members:

--- a/doc/source/neutrino.rst
+++ b/doc/source/neutrino.rst
@@ -1,0 +1,17 @@
+Neutrino Physics: ``snewpy.neutrino``
+=====================================
+
+.. warning::
+
+   This was automatically generated from docstrings in ``neutrino.py`` and still needs some editing.
+   See `the autodoc configuration <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_ for help.
+
+   In particular:
+
+   * The base class ``snewpy.models.SupernovaModel`` should be at the top of the page and highlighted
+   * ``get_time`` and ``get_initialspectra`` have the same signature for most models (apart from the additional interpolation parameter for the ``Fornax`` models); avoid repetitive documentation?
+   * Should ``Tamborra_2014`` and ``Walk_201x`` get a docstring explaining that they are aliases for ``Bollig_2016``?
+
+
+.. automodule:: snewpy.neutrino
+   :members:

--- a/doc/source/snowglobes.rst
+++ b/doc/source/snowglobes.rst
@@ -1,0 +1,41 @@
+Using SNEWPy as a Front End for SNOwGLoBES
+==========================================
+
+.. warning::
+
+   This page summarizes the steps of using SNEWPy as a front end for SNOwGLoBES. Some TODOs:
+
+   * Add some introduction/explanations
+   * Most of the documentation on this page is currently auto-generated from docstrings, but they are incomplete for these modules.
+
+
+Install SNOwGLoBES
+------------------
+Important parts of SNEWPy’s functionality require the `SNOwGLoBES <https://github.com/SNOwGLoBES/snowglobes>`_ and
+`GLoBES <https://www.mpi-hd.mpg.de/personalhomes/globes/>`_ libraries, which need to be installed separately.
+
+.. warning::
+
+   Should we include installation instructions or simply refer to their respective documentation?
+   See https://github.com/SNEWS2/snewpy/issues/26
+
+
+``snewpy.to_snowglobes``
+------------------------
+.. automodule:: snewpy.to_snowglobes
+   :members:
+   :undoc-members:
+
+
+``snewpy.run_snowglobes``
+-------------------------
+.. automodule:: snewpy.run_snowglobes
+   :members:
+   :undoc-members:
+
+
+``snewpy.from_snowglobes``
+--------------------------
+.. automodule:: snewpy.from_snowglobes
+   :members:
+   :undoc-members:

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -1,0 +1,17 @@
+Flavor Transformations: ``snewpy.flavor_transformation``
+========================================================
+
+.. warning::
+
+   This was automatically generated from docstrings in ``flavor_transformation.py`` and still needs some editing.
+   See `the autodoc configuration <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_ for help.
+
+   In particular:
+
+   * The base class ``snewpy.models.FlavorTransformation`` should be at the top of the page and highlighted
+   * The functions ``prob_ee`` (and so on) have the same signature for all transformations. Avoid repetitive documentation?
+   * Purely internal functions (e.g. ``gamma`` in the ``NeutrinoDecay`` transformation) should not appear here.
+
+
+.. automodule:: snewpy.flavor_transformation
+   :members:


### PR DESCRIPTION
This adds the following sections to the documentation:
* Getting Started > Usage
* Using SNEWPy as a Front End for SNOwGLoBES
   * Install SNOwGLoBES
   * `snewpy.to_snowglobes`
   * `snewpy.run_snowglobes`
   * `snewpy.from_snowglobes`
* Supernova Models: `snewpy.models`
* Flavor Transformations: `snewpy.flavor_transformation`
* Neutrino Physics: `snewpy.neutrino`

Most of the content is currently auto-generated from docstrings and will still require editing.