### PR TITLE
always return data tables from collate()

### DIFF
--- a/doc/nb/AnalyticFluence.ipynb
+++ b/doc/nb/AnalyticFluence.ipynb
@@ -222,7 +222,7 @@
     "print(\"Done snowglobes...\")\n",
     "\n",
     "print(\"Collating...\")\n",
-    "tables = snowglobes.collate(SNOwGLoBES_path, tarredoutfile, detector_input=detector, skip_plots=True, return_tables=True)\n",
+    "tables = snowglobes.collate(SNOwGLoBES_path, tarredoutfile, detector_input=detector, skip_plots=True)\n",
     "print()\n",
     "totalcounts = 0\n",
     "for i in range(1,6):\n",

--- a/doc/nb/SNEWPY_examples.ipynb
+++ b/doc/nb/SNEWPY_examples.ipynb
@@ -107,7 +107,7 @@
     "#now collate results of output of snowglobes\n",
     "print(\"Collating...\")\n",
     "# tables = from_snowglobes.collate(SNOwGLoBES_path, modeldir, tarredfile, detector_input=detector,skip_plots=True,return_tables=True,verbose=False)\n",
-    "tables = snowglobes.collate(SNOwGLoBES_path, tarredfile, detector_input=detector,skip_plots=True,return_tables=True,verbose=False)"
+    "tables = snowglobes.collate(SNOwGLoBES_path, tarredfile, detector_input=detector,skip_plots=True,verbose=False)"
    ]
   },
   {

--- a/python/snewpy/from_snowglobes.py
+++ b/python/snewpy/from_snowglobes.py
@@ -5,4 +5,4 @@ from snewpy.snowglobes import collate as NEW_collate
 def collate(Branch, Model_Path, Tarball, detector_input="all", skip_plots=False, return_tables=False, verbose=False, remove_generated_files=True):
     print("[INFO] The `collate` function has been moved to the `snewpy.snowglobes` module.")
     tarball_path = os.path.join(Model_Path, Tarball)
-    return NEW_collate(Branch, tarball_path, detector_input, skip_plots, return_tables, verbose, remove_generated_files)
+    return NEW_collate(Branch, tarball_path, detector_input, skip_plots, verbose, remove_generated_files)

--- a/python/snewpy/scripts/SNEWS2.0_rate_table.py
+++ b/python/snewpy/scripts/SNEWS2.0_rate_table.py
@@ -38,7 +38,7 @@ if (have_data_saved is False):
             tarredfile = snowglobes.generate_fluence(model_dir + file_name, modeltype, transformation, d, outfile)
             for det in dets:
                 snowglobes.simulate(SNOwGLoBES_path, tarredfile, detector_input=det)
-                tables = snowglobes.collate(SNOwGLoBES_path, tarredfile, detector_input=det, skip_plots=True, return_tables=True)
+                tables = snowglobes.collate(SNOwGLoBES_path, tarredfile, detector_input=det, skip_plots=True)
 
                 #for our table, interesting number is the smeared total number of events
                 key = "Collated_"+outfile+"_"+det+"_events_smeared_weighted.dat"

--- a/python/snewpy/scripts/SNEWS2.0_rate_table_singleexample.py
+++ b/python/snewpy/scripts/SNEWS2.0_rate_table_singleexample.py
@@ -22,7 +22,7 @@ print("Simulating detector effects with SNOwGLoBES ...")
 snowglobes.simulate(SNOwGLoBES_path, tarredfile, detector_input=detector)
 
 print("Collating results ...")
-tables = snowglobes.collate(SNOwGLoBES_path, tarredfile, detector_input=detector, skip_plots=True, return_tables=True)
+tables = snowglobes.collate(SNOwGLoBES_path, tarredfile, detector_input=detector, skip_plots=True)
 
 
 # Use results to print the number of events in different interaction channels

--- a/python/snewpy/snowglobes.py
+++ b/python/snewpy/snowglobes.py
@@ -752,7 +752,7 @@ def simulate(SNOwGLoBESdir, tarball_path, detector_input="all", verbose=False):
                 print('\n'*3)
 
 
-def collate(SNOwGLoBESdir, tarball_path, detector_input="all", skip_plots=False, return_tables=False, verbose=False, remove_generated_files=True):
+def collate(SNOwGLoBESdir, tarball_path, detector_input="all", skip_plots=False, verbose=False, remove_generated_files=True):
     """Collates SNOwGLoBES output files and generates plots or returns a data table.
 
     Parameters
@@ -765,8 +765,6 @@ def collate(SNOwGLoBESdir, tarball_path, detector_input="all", skip_plots=False,
         Name of detector. If ``"all"``, will use all detectors supported by SNOwGLoBES.
     skip_plots: bool
         If False, it gives as output the plot of the energy distribution for each time bin and for each interaction channel.
-    return_tables: bool
-        If True, the data tables are returned as output. 
     verbose : bool
         Whether to generate verbose output, e.g. for debugging.
     remove_generated_files: bool
@@ -774,9 +772,8 @@ def collate(SNOwGLoBESdir, tarball_path, detector_input="all", skip_plots=False,
 
     Returns
     -------
-    dict or None
-        If ``return_tables`` is set to ``True``, it returns the data tables. It provides a Table per time bin. The tables contain in the first column the energy bins, in the remaining columns, the number of events for each interaction channel in the detector.
-        
+    dict
+        Dictionary of data tables: One table per time bin; each table contains in the first column the energy bins, in the remaining columns the number of events for each interaction channel in the detector.
     """
     model_dir, tarball = os.path.split(os.path.abspath(tarball_path))
 
@@ -1107,15 +1104,13 @@ def collate(SNOwGLoBESdir, tarball_path, detector_input="all", skip_plots=False,
             continue
     tar.close()
 
-    if return_tables:
-        returned_tables = {}
-        for file in os.listdir(SNOwGLoBESdir + "/out"):
-            if "Collated" in str(file):
-                returned_tables[file] = {}
-                fstream = open(SNOwGLoBESdir + "/out/"+file, 'r')
+    returned_tables = {}
+    for file in os.listdir(SNOwGLoBESdir + "/out"):
+        if "Collated" in str(file):
+            returned_tables[file] = {}
+            with open(SNOwGLoBESdir + "/out/"+file, 'r') as fstream:
                 returned_tables[file]['header'] = fstream.readline()
-                fstream.close()
-                returned_tables[file]['data'] = np.loadtxt(SNOwGLoBESdir + "/out/" + file, skiprows=2, unpack=True)
+            returned_tables[file]['data'] = np.loadtxt(SNOwGLoBESdir + "/out/" + file, skiprows=2, unpack=True)
 
     #removes all snowglobes output files, collated files, and .png's made for this snewpy run
     if remove_generated_files:
@@ -1130,5 +1125,4 @@ def collate(SNOwGLoBESdir, tarball_path, detector_input="all", skip_plots=False,
     except OSError:
         pass
 
-    if return_tables:
-        return returned_tables
+    return returned_tables


### PR DESCRIPTION
Remove `return_tables` argument and always return them. The performance cost of reading this data is negligible, and if the user doesn’t need it, they can always ignore the return value.