### PR TITLE
Vectorize NeutrinoDecay

### DIFF
--- a/python/snewpy/flavor_transformation.py
+++ b/python/snewpy/flavor_transformation.py
@@ -1144,23 +1144,14 @@ class NeutrinoDecay(FlavorTransformation):
         prob : float or ndarray
             Transition probability.
         """
-        pe_array = []
-
         # NMO case.
         if self.mass_order == MassHierarchy.NORMAL:
-            for energy in E:
-                pe_array.append(
-                    self.De1*(1-np.exp(-self.gamma(energy)*self.d)) +
-                    self.De3*np.exp(-self.gamma(energy)*self.d))
-            pe_array = np.array(pe_array)
+            pe_array = self.De1*(1-np.exp(-self.gamma(E)*self.d)) + \
+                       self.De3*np.exp(-self.gamma(E)*self.d))
         # IMO case.
         else:
-            for energy in E:
-                pe_array.append(
-                    self.De2*np.exp(-self.gamma(energy)*self.d) +
-                    self.De3*(1-np.exp(-self.gamma(energy)*self.d)))
-            pe_array = np.array(pe_array)
-
+            pe_array = self.De2*np.exp(-self.gamma(E)*self.d) + \
+                       self.De3*(1-np.exp(-self.gamma(E)*self.d)))
         return pe_array
 
     def prob_ex(self, t, E):
@@ -1251,23 +1242,14 @@ class NeutrinoDecay(FlavorTransformation):
         prob : float or ndarray
             Transition probability.
         """
-        pxbar_array = []
-
         # NMO case.
         if self.mass_order == MassHierarchy.NORMAL:
-            for energy in E:
-                pxbar_array.append(
-                    self.De1*(1-np.exp(-self.gamma(energy)*self.d)) +
-                    self.De2 + self.De3*np.exp(-self.gamma(energy)*self.d))
-            pxbar_array = np.array(pxbar_array)
+            pxbar_array = self.De1*(1-np.exp(-self.gamma(E)*self.d)) + \ 
+                          self.De2 + self.De3*np.exp(-self.gamma(E)*self.d)
         # IMO case.
         else:
-            for energy in E:
-                pxbar_array.append(
-                    self.De1 + self.De2*np.exp(-self.gamma(energy)*self.d) +
-                    self.De3*(1-np.exp(-self.gamma(energy)*self.d)))
-            pxbar_array = np.array(pxbar_array)
-
+            pxbar_array = self.De1 + self.De2*np.exp(-self.gamma(E)*self.d) + \
+                          self.De3*(1-np.exp(-self.gamma(E)*self.d))
         return pxbar_array
 
     def prob_xxbar(self, t, E):

--- a/python/snewpy/flavor_transformation.py
+++ b/python/snewpy/flavor_transformation.py
@@ -1147,11 +1147,11 @@ class NeutrinoDecay(FlavorTransformation):
         # NMO case.
         if self.mass_order == MassHierarchy.NORMAL:
             pe_array = self.De1*(1-np.exp(-self.gamma(E)*self.d)) + \
-                       self.De3*np.exp(-self.gamma(E)*self.d))
+                       self.De3*np.exp(-self.gamma(E)*self.d)
         # IMO case.
         else:
             pe_array = self.De2*np.exp(-self.gamma(E)*self.d) + \
-                       self.De3*(1-np.exp(-self.gamma(E)*self.d)))
+                       self.De3*(1-np.exp(-self.gamma(E)*self.d))
         return pe_array
 
     def prob_ex(self, t, E):

--- a/python/snewpy/flavor_transformation.py
+++ b/python/snewpy/flavor_transformation.py
@@ -1244,7 +1244,7 @@ class NeutrinoDecay(FlavorTransformation):
         """
         # NMO case.
         if self.mass_order == MassHierarchy.NORMAL:
-            pxbar_array = self.De1*(1-np.exp(-self.gamma(E)*self.d)) + \ 
+            pxbar_array = self.De1*(1-np.exp(-self.gamma(E)*self.d)) + \
                           self.De2 + self.De3*np.exp(-self.gamma(E)*self.d)
         # IMO case.
         else:


### PR DESCRIPTION
These changes compute the NeutrinoDecay probabilities using numpy broadcasting. It should run considerably faster. Running Flavor_XForm.ipynb locally, the cells associated with NeutrinoDecay ran 86 times faster (evaluated by ipython `timeit` magic command).

Fixes #31, closes #34 