### PR TITLE
Prevent running integration tests on draft PR

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [review_requested, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
I think my commits might have been heavy for the runner, sorry.
Let's run the tests only when pull request is in a ready state.