### PR TITLE
Cleanup

### DIFF
--- a/python/snewpy/__init__.py
+++ b/python/snewpy/__init__.py
@@ -7,7 +7,6 @@ snewpy
 Front-end for supernova models which provide neutrino luminosity and spectra.
 """
 
-from __future__ import absolute_import
 from ._version import __version__
 import os
 

--- a/python/snewpy/snowglobes.py
+++ b/python/snewpy/snowglobes.py
@@ -19,8 +19,6 @@ There are three basic steps to using SNOwGLoBES from SNEWPY:
     The output tables allow to build the detected neutrino energy spectrum and neutrino time distribution, for each reaction channel or the sum of them.
 """
 
-from __future__ import unicode_literals
-
 import io
 import logging
 import os

--- a/python/snewpy/snowglobes.py
+++ b/python/snewpy/snowglobes.py
@@ -355,7 +355,7 @@ def simulate(SNOwGLoBESdir, tarball_path, detector_input="all", verbose=False):
     np.save(cache_file, result)
     return result 
 
-re_chan_label = re.compile('nu(e|mu|tau)(bar|)_([A-Z][a-z]*)(\d*)_?(.*)')
+re_chan_label = re.compile(r'nu(e|mu|tau)(bar|)_([A-Z][a-z]*)(\d*)_?(.*)')
 def get_channel_label(c):
     mapp = {'nc':'NeutralCurrent',
             'ibd':'Inverse Beta Decay',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if os.path.exists('README.md'):
 # See https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 # setup_keywords['entry_points'] = {'console_scripts': ['to_snowglobes = snewpy.to_snowglobes:generate_time_series', ], },
 setup_keywords['provides'] = [setup_keywords['name']]
-setup_keywords['requires'] = ['Python (>3.3.0)']
+setup_keywords['python_requires'] = '>=3.7'
 setup_keywords['zip_safe'] = False
 setup_keywords['packages'] = find_packages('python')
 setup_keywords['package_dir'] = {'': 'python'}

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,25 @@
 #!/usr/bin/env python
 #
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
-#
-# Standard imports
-#
-from glob import glob
+
 import os
-import re
-import sys
-#
 from distutils.command.sdist import sdist as DistutilsSdist
 from setuptools import setup, find_packages
-#
+
 # Git-based version info. Remove?
-#
 from python.snewpy._git import get_version, SetVersion
+
 #
 # Begin setup
 #
 setup_keywords = dict()
 #
 setup_keywords['name'] = 'snewpy'
-setup_keywords['description'] = 'SNEWS2 supernova simulation package'
-setup_keywords['author'] = 'SNEWS2 Collaboration'
+setup_keywords['description'] = 'A Python package for working with supernova neutrinos'
+setup_keywords['author'] = 'SNEWS Collaboration'
 setup_keywords['author_email'] = 'snews2.0@lists.bnl.gov'
 setup_keywords['license'] = 'BSD'
-setup_keywords['url'] = 'https://github.com/SNEWS2/supernova_models'
+setup_keywords['url'] = 'https://github.com/SNEWS2/snewpy'
 setup_keywords['version'] = get_version()
 #
 # Use README.md as a long_description.
@@ -45,7 +38,6 @@ if os.path.exists('README.md'):
 setup_keywords['provides'] = [setup_keywords['name']]
 setup_keywords['requires'] = ['Python (>3.3.0)']
 setup_keywords['zip_safe'] = False
-setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('python')
 setup_keywords['package_dir'] = {'': 'python'}
 setup_keywords['package_data'] = {'':['templates/*.glb']}


### PR DESCRIPTION
Removes unused imports, eliminates a warning when running `pytest` and enforces the Python version requirement in line with [our integration test](https://github.com/SNEWS2/snewpy/pull/154/commits/29dbe1eeb27e0fe6b3510be741b7662cd997b9d9).