### PR TITLE
Add rate computation without GLOBES

### DIFF
--- a/python/snewpy/scripts/Convert_to_ROOT.py
+++ b/python/snewpy/scripts/Convert_to_ROOT.py
@@ -2,9 +2,13 @@
 """ This module allows to gather the SNOwGLoBES outputs into a ROOT files with 2D histograms.
     These 2D histograms show the rate as a function of time and energy for any given interaction channel.
     There is one ROOT file per detector, per smearing option, and per weighting option.
+    Generate a tarball with the input files by running
+            snowglobes.generate_time_series(...)
+            snowglobes.simulate(...)
+            snowglobes.collate(...)
 
-    To run the code, use:
-        python Convert_to_ROOT.py --path <path to the tar folder with collated outputs>
+    Then, to run the code, use:
+        python Convert_to_ROOT.py <path to the tar file with collated outputs>
 """
 
 import tarfile
@@ -18,7 +22,7 @@ import ROOT
 
 # Get the path to input files (command line argument). Default is current folder
 parser = argparse.ArgumentParser()
-parser.add_argument('--path', help='Path to collated SNEWPY outputs', default = '.')
+parser.add_argument('path', help='Path to tarball containing collated SNEWPY outputs')
 args = parser.parse_args()
 
 tarball_path = args.path

--- a/python/snewpy/snowglobes.py
+++ b/python/snewpy/snowglobes.py
@@ -36,7 +36,7 @@ from tqdm.auto import tqdm
 import snewpy.models
 from snewpy.flavor_transformation import *
 from snewpy.neutrino import Flavor, MassHierarchy
-from snewpy.snowglobes_interface import SNOwGLoBES
+from snewpy.snowglobes_interface import SNOwGLoBES, SimpleRate
 
 logger = logging.getLogger(__name__)
 
@@ -334,7 +334,7 @@ def simulate(SNOwGLoBESdir, tarball_path, detector_input="all", verbose=False, d
         Whether to account for detector smearing and efficiency.
     """
     
-    sng = SNOwGLoBES(SNOwGLoBESdir, detector_effects=detector_effects)
+    sng = SNOwGLoBES(SNOwGLoBESdir) if detector_effects else SimpleRate(SNOwGLoBESdir)
     if detector_input == 'all':
         detector_input = list(sng.detectors)
         detector_input.remove('d2O')
@@ -351,7 +351,7 @@ def simulate(SNOwGLoBESdir, tarball_path, detector_input="all", verbose=False, d
         if len(detector_input)>0:
             detector_input = tqdm(detector_input, desc='Detectors', leave=False)
         for det in detector_input:
-            res=sng.run(flux_files, det, detector_effects=detector_effects)
+            res=sng.run(flux_files, det)
             result[det]=dict(zip((f.stem for f in flux_files),res))
 
     # save result to file for re-use in collate()

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -218,6 +218,7 @@ class Runner:
     def __post_init__(self):
         self.channels=self.sng.channels[self.material]
         self.binning=self.sng.binning[self.material]
+        self.efficiency=self.sng.efficiencies[self.detector]
         self.det_config=self.sng.detectors[self.detector]
         self.base_dir=self.sng.base_dir
         self.out_dir=self.base_dir/'out'
@@ -283,9 +284,14 @@ class Runner:
         else:
             raise RuntimeError('SNOwGLoBES run failed:\n'+stderr)
 
-class SimpleRate(SNOwGLoBES):
+class SimpleRate():
     def __init__(self, base_dir:Path=''):
-        """ SNOwGLoBES interface 
+        """ Simple rate calculation interface 
+        Computes expected rate for a perfect detector (100% efficiencies, no smearing)
+        without using GLOBES. The formula for the rate is
+                Rate = [cross-section in 10^-38 cm^2] x 10^-38 x [fluence in cm^-2] x [target mass in kton] 
+                    x [Dalton per kton] x [energy bin size in GeV]
+        with [target mass in kton] x [Dalton per kton] = number of reference targets in experiment.
 
         Parameters
         ----------
@@ -307,12 +313,6 @@ class SimpleRate(SNOwGLoBES):
         self._load_channels(self.base_dir/'channels')
 
     def _compute_rates(self, detector, material, flux_file:Path):
-        """ Compute expected rate for a perfect detector (100% efficiencies, no smearing)
-            without using GLOBES. The formula for the rate is
-                 Rate = [cross-section in 10^-38 cm^2] x 10^-38 x [fluence in cm^-2] x [target mass in kton] 
-                        x [Dalton per kton] x [energy bin size in GeV]
-            with [target mass in kton] x [Dalton per kton] = number of reference targets in experiment.
-        """
         flux_file = flux_file.resolve()
         fluxes = np.loadtxt(flux_file)
         TargetMass = self.detectors[detector].tgt_mass

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -276,7 +276,6 @@ class Runner:
             flavor_index = 0 if 'e' in channel.flavor else (1 if 'm' in channel.flavor else 2)
             flavor = flavor_index + (3 if channel.parity == '-' else 0)
             flux = fluxes[:, (0,1+flavor)]
-            xen = 10**xsec[:, 0]
             energies = np.linspace(7.49e-4, 9.975e-2, 200) # Use the same energy grid as SNOwGLoBES
             binsize = energies[1] - energies[0]
             # Cross-section in 10^-38 cm^2

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -67,7 +67,7 @@ def guess_material(detector):
     return mat
 
 class SNOwGLoBES:
-    def __init__(self, base_dir:Path='', detector_effects = True):
+    def __init__(self, base_dir:Path=''):
         """ SNOwGLoBES interface 
 
         Parameters
@@ -75,8 +75,6 @@ class SNOwGLoBES:
         base_dir: Path or None
             Path to the SNOwGLoBES installation.
             If empty, try to get it from $SNOWGLOBES environment var
-        detector_effects: bool
-            Account for smearing effects and efficiencies (default: True)
 
 
         On construction SNOwGLoBES will read: 
@@ -92,18 +90,11 @@ class SNOwGLoBES:
         self.base_dir = Path(base_dir)
         self._load_detectors(self.base_dir/'detector_configurations.dat')
         self._load_channels(self.base_dir/'channels')
-        if detector_effects:
-            self._load_efficiencies(self.base_dir/'effic')
-            self._load_smearing(self.base_dir/'smear')
-        else:
-            self.efficiencies = None
-            self.smearings = None
+        self._load_efficiencies(self.base_dir/'effic')
+        self._load_smearing(self.base_dir/'smear')
 
         env = jinja2.Environment(loader=jinja2.PackageLoader('snewpy'), enable_async=True)
-        if detector_effects:
-            self.template = env.get_template('supernova.glb')
-        else:
-            self.template = None
+        self.template = env.get_template('supernova.glb')
 
     def _load_detectors(self, path:Path):
         df = pd.read_table(path,names=['name','mass','factor'], delim_whitespace=True, comment='#')
@@ -151,7 +142,7 @@ class SNOwGLoBES:
         logger.debug(f'efficiencies: {self.efficiencies}')
 
        
-    def run(self, flux_files, detector:str, material:str=None, detector_effects:bool=True):
+    def run(self, flux_files, detector:str, material:str=None):
         """ Run the SNOwGLoBES simulation for given configuration,
         collect the resulting data and return it in `pandas.DataFrame`
 
@@ -163,8 +154,6 @@ class SNOwGLoBES:
             Detector name, known to SNOwGLoBES
         material: str or None
             Material name, known to SNOwGLoBES. If None, we'll try to guess it
-        detector_effects: bool
-            Account for smearing effects and efficiencies (default: True)
 
         Returns
         --------
@@ -190,17 +179,16 @@ class SNOwGLoBES:
             material = guess_material(detector)
         if not material in self.materials:
             raise ValueError(f'Material "{material}" is not in {self.materials}')
-        if detector_effects:
-            if not self.efficiencies[detector]:
-                logger.warning(f'Missing efficiencies for detector={detector}! Results will assume 100% efficiency')
-            if not self.smearings[detector]:
-                logger.warning(f'Missing smearing for detector={detector}! Results will not be smeared')
+        if not self.efficiencies[detector]:
+            logger.warning(f'Missing efficiencies for detector={detector}! Results will assume 100% efficiency')
+        if not self.smearings[detector]:
+            logger.warning(f'Missing smearing for detector={detector}! Results will not be smeared')
         if isinstance(flux_files,str):
             flux_files = [flux_files]
         
         with tqdm(total=len(flux_files), leave=False, desc='Flux files') as progressbar:
             def do_run(file):
-                result =  Runner(self,Path(file),detector,material,detector_effects).run()
+                result =  Runner(self,Path(file),detector,material).run()
                 progressbar.update()
                 return result
 
@@ -215,19 +203,14 @@ class Runner:
     flux_file: Path
     detector: str
     material: str
-    detector_effects: bool
     
     def __post_init__(self):
         self.channels=self.sng.channels[self.material]
+        self.efficiency=self.sng.efficiencies[self.detector]
+        self.smearing=self.sng.smearings[self.detector]
         self.det_config=self.sng.detectors[self.detector]
         self.base_dir=self.sng.base_dir
         self.out_dir=self.base_dir/'out'
-        if self.detector_effects:
-            self.efficiency=self.sng.efficiencies[self.detector]
-            self.smearing=self.sng.smearings[self.detector]
-        else:
-            self.efficiency=None
-            self.smearing=None
             
     def _generate_globes_config(self):
         cfg =  self.sng.template.render(flux_file=self.flux_file.resolve(),
@@ -265,60 +248,133 @@ class Runner:
         df.columns.rename(['channel','is_smeared','is_weighted'], inplace=True)
         return df.reorder_levels([2,1,0], axis='columns')
 
-    def _compute_rates(self):
-        flux_file = self.flux_file.resolve()
+    def run(self):
+        """write configuration file and run snowglobes"""
+        cfg = self._generate_globes_config()
+        chan_file = self.sng.chan_dir/f'channels_{self.material}.dat'
+        #this section is exclusive to one process at a time, 
+        # because snowglobes must  read the "$SNOGLOBES/supernova.glb" file
+        with self.sng.lock:
+            #write configuration file:
+            with open(self.base_dir/'supernova.glb','w') as f:
+                f.write(cfg)
+            #run the snowglobes process:
+            p = subprocess.run(['bin/supernova', self.flux_file.stem, str(chan_file), self.detector],
+                capture_output=True,
+                cwd=self.base_dir)
+        #process the output
+        stdout = p.stdout.decode('utf_8')
+        stderr = p.stderr.decode('utf_8')
+        if(stderr):
+            logger.error('Run errors: \n'+stderr)
+        if(p.returncode==0):
+            tables = self._parse_output(stdout.split('\n'))
+            return tables
+        else:
+            raise RuntimeError('SNOwGLoBES run failed:\n'+stderr)
+
+class SimpleRate(SNOwGLoBES):
+    def __init__(self, base_dir:Path=''):
+        """ SNOwGLoBES interface 
+
+        Parameters
+        ----------
+        base_dir: Path or None
+            Path to the .
+            If empty, try to get it from $SNOWGLOBES environment var
+
+        On construction the code will read: 
+
+        * detectors from `<base_dir>/detector_configurations.dat`,
+        * channels  from `<base_dir>/channels/channel_*.dat`
+
+        After that use :meth:`SimpleRate.run` method to run the simulation for specific detector and flux file.
+        """
+        if not base_dir:
+            base_dir = os.environ['SNOWGLOBES']
+        self.base_dir = Path(base_dir)
+        self._load_detectors(self.base_dir/'detector_configurations.dat')
+        self._load_channels(self.base_dir/'channels')
+
+    def _compute_rates(self, detector, material, flux_file:Path):
+        """ Compute expected rate for a perfect detector (100% efficiencies, no smearing)
+            without using GLOBES. The formula for the rate is
+                 Rate = [cross-section in 10^-38 cm^2] x 10^-38 x [fluence in cm^-2] x [target mass in kton] 
+                        x [Dalton per kton] x [energy bin size in GeV]
+            with [target mass in kton] x [Dalton per kton] = number of reference targets in experiment.
+        """
+        flux_file = flux_file.resolve()
         fluxes = np.loadtxt(flux_file)
-        TargetMass = self.det_config.tgt_mass
-        infos = []
-        for chan_num,channel in enumerate(self.channels.itertuples()):
+        TargetMass = self.detectors[detector].tgt_mass
+        data = {}
+        energies = np.linspace(7.49e-4, 9.975e-2, 200) # Use the same energy grid as SNOwGLoBES
+        for chan_num,channel in enumerate(self.channels[material].itertuples()):
             xsec_path = f"xscns/xs_{channel.name}.dat"
             xsec = np.loadtxt(self.base_dir/xsec_path)
             flavor_index = 0 if 'e' in channel.flavor else (1 if 'm' in channel.flavor else 2)
             flavor = flavor_index + (3 if channel.parity == '-' else 0)
             flux = fluxes[:, (0,1+flavor)]
-            energies = np.linspace(7.49e-4, 9.975e-2, 200) # Use the same energy grid as SNOwGLoBES
             binsize = energies[1] - energies[0]
             # Cross-section in 10^-38 cm^2
             xsecs = np.interp(np.log(energies)/np.log(10), xsec[:, 0], xsec[:, 1+flavor], left=0, right=0) * energies
-            # Fluence (flux integrated over time bin) in cm^-2 (must be divided by 0.2 MeV to compensate the multiplication in generate_time_series)
+            # Fluence (flux integrated over time bin) in cm^-2 
+            # (must be divided by 0.2 MeV to compensate the multiplication in generate_time_series)
             fluxs = np.interp(energies, flux[:, 0], flux[:, 1], left=0, right=0)/2e-4
-            # Rate: [cross-section in 10^-38 cm^2] x 10^-38 x [fluence in cm^-2] x [target mass in kton] x [Dalton per kton] x [energy bin size in GeV]
-            # [target mass in kton] x [Dalton per kton] = number of reference targets in experiment
+            # Rate computation
             rates = xsecs * 1e-38 * fluxs * float(TargetMass) * 1./1.661e-33 * binsize
-            # Save to file
-            outname = f"{flux_file}_{channel.name}_events_unsmeared_unweighted.dat"
-            outfile = self.base_dir/outname
-            np.savetxt(outfile, np.column_stack((energies,rates)))
-            infos.append(f"{chan_num} {outname}")
-        return infos
+            # Weighting
+            weighted_rates = rates * channel.weight
+            # Write to dictionary
+            data[(channel.name,'unsmeared','unweighted')] = rates
+            data[(channel.name,'unsmeared','weighted')] = weighted_rates
+        #collect everything to pandas DataFrame
+        df = pd.DataFrame(data, index = energies)
+        df.index.rename('E', inplace=True)
+        df.columns.rename(['channel','is_smeared','is_weighted'], inplace=True)
+        return df.reorder_levels([2,1,0], axis='columns')
+       
+    def run(self, flux_files, detector:str, material:str=None):
+        """ Compute expected rates for given configuration,
+        collect the resulting data and return it in `pandas.DataFrame`
 
-    def run(self):
-        """if not perfect detector: write configuration file and run snowglobes
-           if perfect detector: compute rates directly"""
-        chan_file = self.sng.chan_dir/f'channels_{self.material}.dat'
-        out_info = None
-        if self.detector_effects:
-            cfg = self._generate_globes_config()
-            #this section is exclusive to one process at a time, 
-            # because snowglobes must  read the "$SNOGLOBES/supernova.glb" file
-            with self.sng.lock:
-                #write configuration file:
-                with open(self.base_dir/'supernova.glb','w') as f:
-                    f.write(cfg)
-                #run the snowglobes process:
-                p = subprocess.run(['bin/supernova', self.flux_file.stem, str(chan_file), self.detector],
-                    capture_output=True,
-                    cwd=self.base_dir)
-            #process the output
-            stdout = p.stdout.decode('utf_8')
-            stderr = p.stderr.decode('utf_8')
-            if(stderr):
-                logger.error('Run errors: \n'+stderr)
-            if(p.returncode):
-                raise RuntimeError('SNOwGLoBES run failed:\n'+stderr)
-            else:
-                out_info = stdout.split('\n')
-        else:
-            out_info = self._compute_rates() 
-        tables = self._parse_output(out_info)
-        return tables
+        Parameters
+        -----------
+        flux_files: list(str) or str
+            An iterable of flux table filenames to process, or a single filename
+        detector: str
+            Detector name, SNOwGLoBES style
+        material: str or None
+            Material name, SNOwGLoBES style. If None, we'll try to guess it
+
+        Returns
+        --------
+        list(pd.DataFrame or Exception)
+            List with the data table for each flux_file, keeping the order.
+            Each table containing Energy (GeV) as index values, 
+            and number of events for each energy bin, for all interaction channels.
+            Columns are hierarchical: (is_weighted, channel),
+            so one can easily access the desired final table. 
+            If run failed with exception, this exception will be returned (not raised).
+
+        Raises
+        ------
+        ValueError
+            if material or detector value is invalid
+
+        """
+        if not  detector in self.detectors:
+            raise ValueError(f'Detector "{detector}" is not in {list(self.detectors)}')
+        if material is None:
+            material = guess_material(detector)
+        if not material in self.materials:
+            raise ValueError(f'Material "{material}" is not in {self.materials}')
+        if isinstance(flux_files,str):
+            flux_files = [flux_files]
+        
+        with tqdm(total=len(flux_files), leave=False, desc='Flux files') as progressbar:
+            results = []
+            for flux_file in flux_files:
+                result = self._compute_rates(detector,material,Path(flux_file))
+                progressbar.update()
+                results.append(result)
+            return results


### PR DESCRIPTION
Since someone in my group didn't want to install GLoBES, I modified the Snowglobes interface to allow to compute the expected rates using only the SNOwGLoBES detector configurations and cross-sections. Here, the rates are computed for a perfect detector (no smearing, 100% efficiencies). I added options in snowglobles.simulate and snowglobes.collate in order to choose to compute this rate if needed.
Running this code for IceCUBE and for the Nakazato 2013 model with 30 bins (default options in scripts/TimeSeries.py), I found that the discrepancies between the new and old unsmeared rates were of at most 0.4%.