### PR TITLE
Fix flavour check for `PinchedModel`

### DIFF
--- a/python/snewpy/models/base.py
+++ b/python/snewpy/models/base.py
@@ -202,7 +202,7 @@ class PinchedModel(SupernovaModel):
         metadata: dict
             Model parameters dict
         """
-        if not 'L_NU_X_BAR' in simtab:
+        if not 'L_NU_X_BAR' in simtab.colnames:
             # table only contains NU_E, NU_E_BAR, and NU_X, so double up
             # the use of NU_X for NU_X_BAR.
             for val in ['L','E','ALPHA']:


### PR DESCRIPTION
Fixes `PinchedModel.__init__()` to check whether 'L_NU_X_BAR' is among the column names; previously, it looked for that string in the table entries.
(This means that before this fix, SNEWPY would always use NU_X data for NU_X_BAR columns, even if NU_X_BAR data had been provided. In practice, none of the included models did provide NU_X_BAR data separately, so this didn’t have any effects.)

This fixes a `FutureWarning` (NumPy <=1.22) or `TypeError` (NumPy 1.23) in the tests and makes them run faster as a side effect. (Comparing the string to a handful of column names, rather than to thousands of table rows, saves _a lot_ of time.)