### PR TITLE
Require AstroPy >=4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy >= 1.16
 scipy
-astropy
+astropy >=4.3
 pandas == 1.3.4
 Jinja2==3.0.2
 tqdm


### PR DESCRIPTION
Fixes #188. AstroPy 4.3 still supports Python 3.7 or higher (same as SNEWPY), so this won’t affect backwards compatibility.