### PR TITLE
extend .gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@ dist/
 # default directory for downloaded model files
 SNEWPY_models/
 
+# snewpy.snowglobes output files
+*_SNOprocessed.tar.gz
+*.npy
+
+# used for integration tests in test_snowglobes.py
+fluence_Bollig_2016_s*
+
 # editor-specific
 .ipynb_checkpoints/
 .vscode/


### PR DESCRIPTION
Ignore output files from running `snewpy.snowglobes` as well as files generated during integration tests in `test_snowglobes.py`.