### PR TITLE
Fix issue with he detectors

### DIFF
--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -160,7 +160,7 @@ class SimpleRate():
         data = {}
         energies = np.linspace(7.49e-4, 9.975e-2, 200) # Use the same energy grid as SNOwGLoBES
         if '_he' in detector:
-            energies = np.linspace(7.49e-4, 2*9.975e-2, 400) #SNOwGLoBES grid for he configurations
+            energies = np.linspace(7.49e-4, 19.975e-2, 400) #SNOwGLoBES grid for he configurations
         for channel in self.channels[material].itertuples():
             xsec_path = f"xscns/xs_{channel.name}.dat"
             xsec = np.loadtxt(self.base_dir/xsec_path)

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -31,6 +31,9 @@ def guess_material(detector):
         mat = 'scint'
     else: 
         raise ValueError(f'Please provide material for {detector}')
+
+    if '_he' in detector:
+        mat = mat+'_he'
     return mat
 
 
@@ -156,6 +159,8 @@ class SimpleRate():
         TargetMass = self.detectors[detector].tgt_mass
         data = {}
         energies = np.linspace(7.49e-4, 9.975e-2, 200) # Use the same energy grid as SNOwGLoBES
+        if '_he' in detector:
+            energies = np.linspace(7.49e-4, 2*9.975e-2, 400) #SNOwGLoBES grid for he configurations
         for channel in self.channels[material].itertuples():
             xsec_path = f"xscns/xs_{channel.name}.dat"
             xsec = np.loadtxt(self.base_dir/xsec_path)


### PR DESCRIPTION
This should close issue #205

The problem was the following:

- guess_material() was not considering the '_he' in the material name, which was causing that efficiency and smearing files were not found, and those matrices were set to ones. This was producing no error in the ar40kt_he case, but it was not properly running with he eff and smear files.
- for the case of wc100kt30prct_he detector, the oxygen files don't contain '_he' in the channel, but ibd and nu-e ES do. So for the oxygen case, the file name was correctly found, but there was a missmatch with the rates binning, which was set only for the non he case. 