### PR TITLE
Skip integration test for draft PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   run:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,10 +9,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [review_requested, ready_for_review]
 
 jobs:
   build:
+    # Only execute integration test if PR is *not* a draft
+    if: !github.event.pull_request.draft
+
     runs-on: ubuntu-latest
     strategy:
       # Add a list of python versions we want to use for testing.
@@ -48,3 +50,11 @@ jobs:
       - name: Publish benchmark results
         if: ${{ github.event_name == 'pull_request' }}
         uses: nils-braun/pytest-benchmark-commenter@v2
+
+  skip:
+    # Only execute this job if PR *is* a draft
+    if: github.event.pull_request.draft
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Skipping integration test'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-benchmark 
+          pip install pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install SNEWPY
         run: |
@@ -47,7 +47,4 @@ jobs:
         run: |
           export SNOWGLOBES=${GITHUB_WORKSPACE}/opt/snowglobes
           python -m unittest python/snewpy/test/simplerate_integrationtest.py
-          pytest -m 'snowglobes' --benchmark-json output.json
-      - name: Publish benchmark results
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: nils-braun/pytest-benchmark-commenter@v2
+          pytest -m 'snowglobes'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     # Only execute integration test if PR is *not* a draft
-    if: !github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  run:
     # Only execute integration test if PR is *not* a draft
     if: github.event.pull_request.draft == false
 
@@ -50,11 +50,3 @@ jobs:
       - name: Publish benchmark results
         if: ${{ github.event_name == 'pull_request' }}
         uses: nils-braun/pytest-benchmark-commenter@v2
-
-  skip:
-    # Only execute this job if PR *is* a draft
-    if: github.event.pull_request.draft
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo 'Skipping integration test'

--- a/python/snewpy/test/simplerate_integrationtest.py
+++ b/python/snewpy/test/simplerate_integrationtest.py
@@ -71,5 +71,5 @@ class TestSimpleRate(unittest.TestCase):
         discrepancy = abs(sk_computed - sk_expected)/sk_expected
         discrepancy_smeared = abs(sk_computed_smeared - sk_expected_smeared)/sk_expected_smeared
 
-        assert discrepancy < 0.001, f"Number of events computed for SK is {sk_computed}, should be {sk_expected}"
-        assert discrepancy_smeared < 0.001, f"Number of events computed for SK is {sk_computed}, should be {sk_expected}"
+        assert discrepancy < 0.001, f"Number of unsmeared events computed for SK is {sk_computed}, should be {sk_expected}"
+        assert discrepancy_smeared < 0.001, f"Number of smeared events computed for SK is {sk_computed_smeared}, should be {sk_expected_smeared}"

--- a/python/snewpy/test/test_05_snowglobes.py
+++ b/python/snewpy/test/test_05_snowglobes.py
@@ -57,12 +57,3 @@ def test_simplerate_smear_crosscheck(splr, detector, expected_total):
     data = splr.run(flux,detector)
     total = data[0].weighted.smeared.sum().sum()
     assert total == pytest.approx(expected_total, 0.1)
-
-def process(tarball_name):
-    simulate(None,tarball_name,'icecube')
-    collate(None, tarball_name)
-
-@pytest.mark.timing
-def test_simulation_chain_benchmark(benchmark):
-    tarball_name='./models/Bollig_2016/fluence_Bollig_2016_s27.0c_AdiabaticMSW_IMO.tar.bz2'
-    r = benchmark(process,tarball_name)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ with open('requirements.txt', 'r') as f:
             requires.append(line.strip())
 setup_keywords['install_requires'] = requires
 setup_keywords['extras_require'] = {  # Optional
-    'dev': ['pytest', 'pytest-benchmark'],
+    'dev': ['pytest'],
     'docs':['numpydoc']
 }
 #


### PR DESCRIPTION
In #128, we changed the GitHub workflow so that integration test would not run on draft PRs. Unfortunately, with the solution we found back then, it required manual activity by a developer to run; so it did not run reliably on PRs, which has caused some problems recently.

After looking at the GitHub documentation some more, I think I’ve found a better way to achieve the same thing. I will test in this PR.