### PR TITLE
Release v1.3b2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,8 @@ jobs:
       run: |
         python -c 'import python.snewpy; python.snewpy._get_model_urls()'
         cat python/snewpy/_model_urls.py
-        python -c 'import python.snewpy; python.snewpy.get_models(models="Bollig_2016")'
+        pip install .
+        python -c 'import snewpy; snewpy.get_models(models="Bollig_2016")'
         rm -r SNEWPY_models/
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/python/snewpy/__init__.py
+++ b/python/snewpy/__init__.py
@@ -9,8 +9,13 @@ Front-end for supernova models which provide neutrino luminosity and spectra.
 
 from ._version import __version__
 from pathlib import Path
-from astropy.config.paths import get_cache_dir
 import os
+
+try:
+    from astropy.config.paths import get_cache_dir
+except ModuleNotFoundError:
+    # when imported by setup.py before dependencies are installed
+    get_cache_dir = lambda: '.'
 
 src_path = os.path.realpath(__path__[0])
 base_path = os.sep.join(src_path.split(os.sep)[:-2])

--- a/python/snewpy/_version.py
+++ b/python/snewpy/_version.py
@@ -1,1 +1,1 @@
-__version__ = '1.3b1'
+__version__ = '1.3b2'


### PR DESCRIPTION
As [suggested last week](https://github.com/SNEWS2/snewpy/pull/184#issuecomment-1275059998), this is a new beta release to test more broadly that the changes introduced in #184 are backwards compatible with existing code.

In addition, this PR includes a minor fix to ensure snewpy can be installed in a clean environment without separately installing astropy first. (This caused the readthedocs page for the main branch to fail to build.)