### PR TITLE
add Python 3.11 to test suite; drop 3.7

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       # Add a list of python versions we want to use for testing.
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       # Add a list of python versions we want to use for testing.
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy >= 1.16
 scipy
 astropy >=4.3
-pandas == 1.3.4
+pandas
 tqdm
 matplotlib
 h5py

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if os.path.exists('README.md'):
 # See https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 # setup_keywords['entry_points'] = {'console_scripts': ['to_snowglobes = snewpy.to_snowglobes:generate_time_series', ], },
 setup_keywords['provides'] = [setup_keywords['name']]
-setup_keywords['python_requires'] = '>=3.7'
+setup_keywords['python_requires'] = '>=3.8'
 setup_keywords['zip_safe'] = False
 setup_keywords['packages'] = find_packages('python')
 setup_keywords['package_dir'] = {'': 'python'}


### PR DESCRIPTION
Python 3.11 [was released in late October](https://www.python.org/downloads/release/python-3110/), so this PR adds it to our testing matrix. Looking at the [3.11 release notes](https://docs.python.org/3.11/whatsnew/3.11.html), we should need no further changes for compatibility. Unfortunately, one of snewpy’s dependencies (`h5py`) [hasn’t yet published](https://github.com/h5py/h5py/pull/2165#issuecomment-1302303865) a release that supports 3.11, so unless we install `h5py` from source, snewpy will not yet install under 3.11; so this PR is currently a draft.

At the same time, I would suggest dropping support for Python 3.7 with the next snewpy release. This is in line with much of the scientific Python ecosystem (who [dropped 3.7 support in December 2021](https://numpy.org/neps/nep-0029-deprecation_policy.html)); official end of life for Python 3.7 is [June 2023](https://peps.python.org/pep-0537/#lifespan).