### PR TITLE
Use snowglobes_data package instead of hardcoded path

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,16 +36,7 @@ jobs:
       - name: Install SNEWPY
         run: |
           python setup.py install --user
-      - name: Install SNOwGLoBES
-        run: |
-          mkdir opt
-          cd opt
-          git clone https://github.com/SNOwGLoBES/snowglobes.git
-          cd snowglobes
-          git checkout v1.3
-          export SNOWGLOBES=${PWD}
       - name: Run Integration Tests
         run: |
-          export SNOWGLOBES=${GITHUB_WORKSPACE}/opt/snowglobes
           python -m unittest python/snewpy/test/simplerate_integrationtest.py
           pytest -m 'snowglobes'

--- a/README.md
+++ b/README.md
@@ -31,17 +31,6 @@ To contribute, first clone the repository (`git clone https://github.com/SNEWS2/
 Once you’re happy with your changes, please submit a pull request.
 Unit tests will run automatically for every pull request or you can run them locally using `python -m unittest python/snewpy/test/test_*.py`.
 
-### Dependencies 
-
-Some functionality of SNEWPY requires that [SNOwGLoBES](https://github.com/SNOwGLoBES/snowglobes) is downloaded.
-In your project directory, run the following commands to get SNOwGLoBES and set it up for use with SNEWPY:
-```bash
-	git clone https://github.com/SNOwGLoBES/snowglobes.git
-	cd snowglobes
-	git checkout v1.3
-	export SNOWGLOBES=${PWD}
-```
-
 ## Usage and Documentation
 Example scripts which show how SNEWPY can be used are available in the
 `python/snewpy/scripts/` subfolder as well as notebooks in `doc/nb/`.

--- a/doc/nb/AnalyticFluence.ipynb
+++ b/doc/nb/AnalyticFluence.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "mpl.rc('font', size=14)\n",
     "\n",
-    "SNOwGLoBES_path = \"/path/to/snowglobes/\"  # where SNOwGLoBES is located\n",
+    "SNOwGLoBES_path = None  # change to SNOwGLoBES directory if using a custom detector configuration\n",
     "SNEWPY_models_base = \"/path/to/snewpy/models/\"  # directory where models are located\n",
     "\n",
     "model_folder = f\"{SNEWPY_models_base}/AnalyticFluence/\"\n",

--- a/doc/nb/SNOwGLoBES_usage.ipynb
+++ b/doc/nb/SNOwGLoBES_usage.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "from snewpy import snowglobes\n",
     "\n",
-    "SNOwGLoBES_path = \"/path/to/snowglobes/\"  # where SNOwGLoBES is located\n",
+    "SNOwGLoBES_path = None  # to use custom SNOwGLoBES detector/channel/smearing files, set SNOwGLoBES directory\n",
     "SNEWPY_models_base = \"/path/to/snewpy/models/\"  # directory containing SNEWPY models"
    ],
    "outputs": [],

--- a/doc/source/snowglobes.rst
+++ b/doc/source/snowglobes.rst
@@ -2,17 +2,20 @@ Using SNEWPY as a Front End for SNOwGLoBES
 ==========================================
 
 
-Install SNOwGLoBES
-------------------
-Important parts of SNEWPY’s functionality require `SNOwGLoBES <https://github.com/SNOwGLoBES/snowglobes>`_,
-which needs to be downloaded separately:
+SNEWPY can be used as a Python front-end for `SNOwGLoBES <https://github.com/SNOwGLoBES/snowglobes>`_.
+When installing SNEWPY, it automatically downloads the detector configurations
+from the latest supported SNOwGLoBES version.
+
+You only need to download SNOwGLoBES manually if you require a custom detector
+configuration. In that case, run the following commands:
 
 .. code-block:: bash
 
    git clone https://github.com/SNOwGLoBES/snowglobes.git
    cd snowglobes
    git checkout v1.3
-   export SNOWGLOBES=${PWD}
+   # create custom detector configuration
+   export SNOWGLOBES=${PWD} # or use `SNOwGLoBESdir` parameter as documented below
 
 
 Usage

--- a/python/snewpy/scripts/SNEWS2.0_rate_table.py
+++ b/python/snewpy/scripts/SNEWS2.0_rate_table.py
@@ -6,7 +6,7 @@ from astropy.io import ascii
 from snewpy import snowglobes
 
 home_directory = os.getcwd()
-SNOwGLoBES_path = "/path/to/snowglobes/"  # directory where SNOwGLoBES is located
+SNOwGLoBES_path = None  # change to SNOwGLoBES directory if using a custom detector configuration
 SNEWPY_models_base = "/path/to/snewpy/models/"  # directory containing model input files
 
 d = 10  # distance of supernova in kpc

--- a/python/snewpy/scripts/SNEWS2.0_rate_table_singleexample.py
+++ b/python/snewpy/scripts/SNEWS2.0_rate_table_singleexample.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from snewpy import snowglobes
 
-SNOwGLoBES_path = "/path/to/snowglobes/"  # directory where SNOwGLoBES is located
+SNOwGLoBES_path = None  # change to SNOwGLoBES directory if using a custom detector configuration
 SNEWPY_model_dir = "/path/to/snewpy/models/"  # directory containing model input files
 
 distance = 10  # Supernova distance in kpc

--- a/python/snewpy/scripts/TimeSeries.py
+++ b/python/snewpy/scripts/TimeSeries.py
@@ -2,7 +2,7 @@
 
 from snewpy import snowglobes
 
-SNOwGLoBES_path = "/path/to/snowglobes/"  # where snowglobes is located
+SNOwGLoBES_path = None  # change to SNOwGLoBES directory if using a custom detector configuration
 
 # arguments for generate_time_series
 model_file = "/path/to/snewpy/models/Nakazato_2013/nakazato-LS220-BH-z0.004-s30.0.fits"

--- a/python/snewpy/scripts/snewpy_to_snewpdag.py
+++ b/python/snewpy/scripts/snewpy_to_snewpdag.py
@@ -3,7 +3,7 @@ from snewpy import snowglobes
 import numpy as np
 from astropy import units as u
 
-SNOwGLoBES_path = "/location/of/snowglobes/" #where snowglobes is located
+SNOwGLoBES_path = None  # change to SNOwGLoBES directory if using a custom detector configuration
 SNEWPY_models_base = "/location/of/models/" #where models (aka input for to_snowglobes) is located
 output_path = "/path/to/output/" #where the output files will be located
 

--- a/python/snewpy/snowglobes.py
+++ b/python/snewpy/snowglobes.py
@@ -318,12 +318,13 @@ def generate_fluence(model_path, model_type, transformation_type, d, output_file
     return os.path.join(model_dir, tfname)
 
 def simulate(SNOwGLoBESdir, tarball_path, detector_input="all", verbose=False, *, detector_effects=True):
-    """Takes as input the neutrino flux files and configures and runs the supernova script inside SNOwGLoBES, which outputs calculated event rates expected for a given (set of) detector(s). These event rates are given as a function of the neutrino energy and time, for each interaction channel.
+    """Calculate expected event rates for the given neutrino flux files and the given (set of) SNOwGLoBES detector(s).
+    These event rates are given as a function of the neutrino energy and time, for each interaction channel.
 
     Parameters
     ----------
-    SNOwGLoBESdir : str
-        Path to directory where SNOwGLoBES is installed.
+    SNOwGLoBESdir : str or None
+        Path to SNOwGLoBES directory. Set to ``None`` to automatically use the latest supported SNOwGLoBES release.
     tarball_path : str
         Path of compressed .tar file produced e.g. by ``generate_time_series()`` or ``generate_fluence()``.
     detector_input : str
@@ -382,7 +383,7 @@ def collate(SNOwGLoBESdir, tarball_path, detector_input="", skip_plots=False, ve
 
     Parameters
     ----------
-    SNOwGLoBESdir : str
+    SNOwGLoBESdir : str or None
         [DEPRECATED, DO NOT USE.]
     tarball_path : str
         Path of compressed .tar file produced e.g. by ``generate_time_series()`` or ``generate_fluence()``.

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -18,7 +18,7 @@ from tqdm.auto import tqdm
 
 import snowglobes_data
 import sys
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 9):
     from importlib.resources import files
 else:
     from importlib_resources import files
@@ -79,7 +79,7 @@ class SimpleRate():
             If empty, try to get it from ``$SNOWGLOBES`` environment var or the `snowglobes_data` module.
         """
         try:
-            self.base_dir = Path(base_dir) if base_dir else os.environ['SNOWGLOBES']
+            self.base_dir = Path(base_dir if base_dir else os.environ['SNOWGLOBES'])
         except KeyError:
             print("Using snowglobes_data module ...")
             self.base_dir = files(snowglobes_data)

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -16,6 +16,13 @@ logger = logging.getLogger(__name__)
 
 from tqdm.auto import tqdm
 
+import snowglobes_data
+import sys
+if sys.version_info >= (3, 10):
+    from importlib.resources import files
+else:
+    from importlib_resources import files
+
 def guess_material(detector):
     if detector.startswith('wc') or detector.startswith('ice') or detector.startswith('km3'):
         mat = 'water'
@@ -68,12 +75,14 @@ class SimpleRate():
             If true, account for efficiency and smearing. If false, consider a perfect detector.
 
         base_dir:         Path or None
-            Path to the directory where the cross-section, detector, and channel files are located
-            If empty, try to get it from ``$SNOWGLOBES`` environment var
+            Path to the directory where the cross-section, detector, and channel files are located.
+            If empty, try to get it from ``$SNOWGLOBES`` environment var or the `snowglobes_data` module.
         """
-        if not base_dir:
-            base_dir = os.environ['SNOWGLOBES']
-        self.base_dir = Path(base_dir)
+        try:
+            self.base_dir = Path(base_dir) if base_dir else os.environ['SNOWGLOBES']
+        except KeyError:
+            print("Using snowglobes_data module ...")
+            self.base_dir = files(snowglobes_data)
         self._load_detectors(self.base_dir/'detector_configurations.dat', detectors)
         self._load_channels(self.base_dir/'channels')
         self.efficiencies = None

--- a/python/snewpy/test/simplerate_integrationtest.py
+++ b/python/snewpy/test/simplerate_integrationtest.py
@@ -2,7 +2,6 @@
 """Integration test based on SNEWS2.0_rate_table_singleexample.py
 """
 import unittest
-import os
 from snewpy import snowglobes
 
 
@@ -12,7 +11,7 @@ class TestSimpleRate(unittest.TestCase):
         """Integration test based on SNEWS2.0_rate_table_singleexample.py
         """
         # Hardcoded paths on GitHub Action runner machines
-        SNOwGLoBES_path = os.environ['SNOWGLOBES']
+        SNOwGLoBES_path = None
         SNEWPY_model_dir = "models/"
 
         distance = 10  # Supernova distance in kpc

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ matplotlib
 h5py
 requests
 pyyaml
-importlib_resources; python_version < "3.10"
-snowglobes-data==1.3a1
+importlib_resources; python_version < "3.9"
+snowglobes-data==1.3a2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ matplotlib
 h5py
 requests
 pyyaml
+importlib_resources; python_version < "3.10"
+snowglobes-data==1.3a1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ matplotlib
 h5py
 requests
 pyyaml
+snowglobes_data == 1.3.1
 importlib_resources; python_version < "3.9"
-snowglobes-data==1.3a2


### PR DESCRIPTION
Closes #208. I’ve just filed SNOwGLoBES/snowglobes#21, which would help publish SNOwGLoBES data files as a PyPI package. This would simplify snewpy installation (users no longer need to download SNOwGLoBES manually) and usage (no need to specify the SNOwGLoBES directory in `snewpy.snowglobes` function calls).

To test this:
1. Run `pip install -i https://test.pypi.org/simple/ snowglobes_data`
2. Then install snewpy from this branch
3. Open `SNOwGLoBES_usage.ipynb` and set `SNOwGLoBES_path` to `None`.

This PR is currently marked as a draft, because there are a few open To-Dos:
- [x] Update documentation
- [x] Update example notebook
- [x] Remove need for backported `importlib_resources` library under Python 3.9
- [x] Wait until SNOwGLoBES PR is merged & package is available on regular PyPI.