### PR TITLE
Fixes #267: explicitly call the units decomposition on Container creation

### DIFF
--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -64,6 +64,9 @@ from enum import IntEnum
 from copy import copy
 from functools import wraps
 
+#list of units which will be used as units for decomposition inside the Container
+snewpy_unit_bases = [u.MeV, u.m, u.s, u.kg]
+
 class Axes(IntEnum):
     """Enum to keep the number number of the array dimension for each axis""" 
     flavor=0, #Flavor dimension
@@ -350,7 +353,7 @@ class Container(_ContainerBase):
 
     @wraps(_ContainerBase.__init__)
     def __new__(cls, data,*args, **kwargs):
-        data = data.decompose() #simplify the units, reducing to the bases
+        data = data.decompose(snewpy_unit_bases) #simplify the units, reducing to the bases
         if not cls.unit:
             data = u.Quantity(data)
             cls = cls[data.unit]
@@ -371,7 +374,7 @@ class Container(_ContainerBase):
         
 
 #some standard container classes that can be used for 
-Flux = Container['1/(MeV*s*cm**2)', "d2FdEdT"]
+Flux = Container['1/(MeV*s*m**2)', "d2FdEdT"]
 Fluence = Container[Flux.unit*u.s, "dFdE"]
 Spectrum= Container[Flux.unit*u.MeV, "dFdT"]
 IntegralFlux= Container[Flux.unit*u.s*u.MeV, "dF"]

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -350,6 +350,7 @@ class Container(_ContainerBase):
 
     @wraps(_ContainerBase.__init__)
     def __new__(cls, data,*args, **kwargs):
+        data = data.decompose() #simplify the units, reducing to the bases
         if not cls.unit:
             data = u.Quantity(data)
             cls = cls[data.unit]

--- a/python/snewpy/test/test_flux_container.py
+++ b/python/snewpy/test/test_flux_container.py
@@ -31,7 +31,7 @@ def quantities(draw, values, unit):
 #how to generate axes values
 flavors = st.lists(elements=st.sampled_from(Flavor),
                    unique=True,min_size=1,max_size=len(Flavor)).map(sorted)
-units = st.sampled_from(['1/MeV','1/(MeV*s)','1/(MeV*s*cm**2)']).map(u.Unit)
+units = st.sampled_from(['1/MeV','1/(MeV*s)','1/(MeV*s*m**2)']).map(u.Unit)
 energies = quantities(sorted_floats(shape=array_shapes(max_dims=1)),u.MeV)
 times    = quantities(sorted_floats(shape=array_shapes(max_dims=1)),u.s)
 integrable_axess = st.lists(st.sampled_from(list(Axes)[1:]))


### PR DESCRIPTION
Call "decompose" each time a new Container is created - this should prevent situations like _"cm2/cm2"_ or _"h/min"_ units. 

**Note:** this reduces the units to SI bases. If we want, we can list standard SNEWPY units here, so everything will be converted to them instead.