### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Example scripts which show how SNEWPY can be used are available in the
 `python/snewpy/scripts/` subfolder as well as notebooks in `doc/nb/`.
 Most downloadable models also include a Jupyter notebook with simple usage examples.
 
-A paper describing SNEWPY and the underlying physics is available at [arXiv:2109.08188](https://arxiv.org/abs/2109.08188).
+Papers describing SNEWPY and the underlying physics are published in the Astrophysical Journal ([DOI:10.3847/1538-4357/ac350f](https://dx.doi.org/10.3847/1538-4357/ac350f), [arXiv:2109.08188](https://arxiv.org/abs/2109.08188)) and the Journal of Open Source Software ([DOI:10.21105/joss.03772](https://dx.doi.org/10.21105/joss.03772)).
 
 For more, see the [full documentation on Read the Docs](https://snewpy.rtfd.io/).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,34 @@ Alternatively, you can run the following command to explicitly download models y
 
 
 ## Usage and Documentation
+
+SNEWPY gives you easy access to hundreds of included SN simulations …
+```Python
+import astropy.units as u
+from snewpy.models.ccsn import Nakazato_2013, Bollig_2016
+
+# Initialise two SN models. This automatically downloads the required data files if necessary.
+nakazato = Nakazato_2013(progenitor_mass=20*u.solMass, revival_time=100*u.ms, metallicity=0.004, eos='shen')
+bollig = Bollig_2016(progenitor_mass=27*u.solMass)
+```
+
+… and many flavor transformations that neutrinos could experience on the way to Earth …
+```Python
+from snewpy.flavor_transformations import AdiabaticMSW
+from snewpy.neutrino import MassHierarchy
+
+# Adiabatic MSW flavor transformation with normal mass ordering
+msw_nmo = AdiabaticMSW(mh=MassHierarchy.NORMAL)
+```
+
+… letting you quickly calculate the neutrino flux reaching Earth:
+```Python
+# Assume a SN at the fiducial distance of 10 kpc and normal mass ordering.
+flux = bollig.get_flux(distance=10*u.kpc, transformation=msw_nmo)
+```
+
+You can also calculate the observed event rate in all neutrino detectors supported by SNOwGLoBES, use the included SN models and flavor transformations in event generators like sntools, and much more.
+
 Example scripts which show how SNEWPY can be used are available in the
 `python/snewpy/scripts/` subfolder as well as notebooks in `doc/nb/`.
 Most downloadable models also include a Jupyter notebook with simple usage examples.

--- a/README.md
+++ b/README.md
@@ -14,22 +14,13 @@ SNEWPY is a Python package for working with supernova neutrinos. It offers …
 
 ## Installation
 
-### For Users
 Run `pip install snewpy` to install SNEWPY.
 
-SNEWPY includes a large number of supernova models from different simulation groups. Since these models have a size of several 100 MB, they are not included in the initial install. Instead, after installing, run the following command to download models you want to use:
+SNEWPY includes a large number of supernova models from different simulation groups. Since these models have a size of several 100 MB, they are not included in the initial install but will be downloaded automatically when needed.
+Alternatively, you can run the following command to explicitly download models you want to use to a subdirectory named `SNEWPY-models/<model_name>/` in the current directory:
 
 `python -c 'import snewpy; snewpy.get_models()'`
 
-By default, they will be downloaded to a subdirectory named `SNEWPY-models/<model_name>/` in the current directory.
-
-### For Developers
-
-**Your contributions to SNEWPY are welcome!** For minor changes, simply submit a pull request. If you plan larger changes, it’s probably a good idea to open an issue first to coordinate our work.
-
-To contribute, first clone the repository (`git clone https://github.com/SNEWS2/snewpy.git`), then make changes and install your modified version locally using `pip install .` from the base directory of the repository.
-Once you’re happy with your changes, please submit a pull request.
-Unit tests will run automatically for every pull request or you can run them locally using `python -m unittest python/snewpy/test/test_*.py`.
 
 ## Usage and Documentation
 Example scripts which show how SNEWPY can be used are available in the
@@ -39,3 +30,10 @@ Most downloadable models also include a Jupyter notebook with simple usage examp
 A paper describing SNEWPY and the underlying physics is available at [arXiv:2109.08188](https://arxiv.org/abs/2109.08188).
 
 For more, see the [full documentation on Read the Docs](https://snewpy.rtfd.io/).
+
+## Contributing
+
+**Your contributions to SNEWPY are welcome!** For minor changes, simply submit a pull request. If you plan larger changes, it’s probably a good idea to open an issue first to coordinate our work.
+
+We use a [Fork & Pull Request](https://docs.github.com/en/get-started/quickstart/fork-a-repo) workflow, which is common on GitHub.
+Please see the [Contributing page](https://snewpy.readthedocs.io/en/stable/contributing.html) in our full documentation for details.

--- a/doc/source/citing.rst
+++ b/doc/source/citing.rst
@@ -5,12 +5,12 @@ If you use SNEWPY for your own research, please cite the following two papers:
 
 * \A. L. Baxter `et al.` (SNEWS Collaboration):
   “SNEWPY: A Data Pipeline from Supernova Simulations to Neutrino Signals”.
-  Journal of Open Source Software 6 (2021) 67, 3772.
+  Journal of Open Source Software 6 (2021) 67, 03772.
   [`DOI:10.21105/joss.03772 <https://dx.doi.org/10.21105/joss.03772>`_]
 
 * \A. L. Baxter `et al.` (SNEWS Collaboration):
   “SNEWPY: A Data Pipeline from Supernova Simulations to Neutrino Signals”.
-  Astrophysical Journal (2022), in print.
+  Astrophysical Journal 925 (2022) 107.
   [`arXiv:2109.08188 <https://arxiv.org/abs/2109.08188>`_, `DOI:10.3847/1538-4357/ac350f <https://dx.doi.org/10.3847/1538-4357/ac350f>`_]
 
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -43,7 +43,7 @@ You can then run the tests using the
     pytest
 
 command in the SNEWPY root directory. To skip integration tests which depend
-on SNOwGLoBES---or to run _only_ those tests---you can use one of::
+on SNOwGLoBES (or to run *only* those tests) you can use one of::
 
     pytest -m 'snowglobes'  # only run tests that depend on SNOwGLoBES
     pytest -m 'not snowglobes'

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -17,42 +17,55 @@ Contribute Code or Documentation
 --------------------------------
 **Your contributions to SNEWPY are welcome!**
 
-To contribute, please clone the GitHub repository::
+To contribute, please `create your own fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_
+of the SNEWPY repository [#fn_fork]_, then clone it::
 
-    git clone git@github.com:SNEWS2/snewpy.git
+    git clone git@github.com:<YOUR-USERNAME>/snewpy.git
     cd snewpy/
 
-then make your changes and install the package with the dependencies for the development::
-    
-    pip install ".[dev]"
-
-or, if you want to build the documentation::
-
-    pip install ".[docs]"
-    cd doc/
-    make html
-
+Next, make your changes and try them out. Where relevant, run tests or build
+documentation as described in the following subsections.
 Once you're happy with your changes, please 
-`submit a pull request <https://github.com/SNEWS2/snewpy/pulls>`_.
+`create a pull request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_.
 If you plan larger changes, it’s probably a good idea to open an issue first
 to coordinate our work.
 
-Testing
-~~~~~~~
+Running Tests
+~~~~~~~~~~~~~
 
-SNEWPY uses the `pytest <https://docs.pytest.org>`_ package
-for automated testing. Tests will run when you submit a pull request
-or you can run them manually using::
+SNEWPY uses the `pytest <https://docs.pytest.org>`_ package for automated testing.
+First, to install the necessary packages, use::
+
+    pip install ".[dev]"
+
+You can then run the tests using the
 
     pytest
 
-command in the SNEWPY root directory.
-SNOwGLoBES interface tests requires ``$SNOWGLOBES`` environment variable to be set to the path of you SNOwGLoBES installation.
-If you want to skip this part, use::
-    
-    pytest -k 'not snowglobes'
+command in the SNEWPY root directory. To skip integration tests which depend
+on SNOwGLoBES---or to run _only_ those tests---you can use one of::
 
-to run all tests except those for the SNOwGLoBES interface.
+    pytest -m 'snowglobes'  # only run tests that depend on SNOwGLoBES
+    pytest -m 'not snowglobes'
+
+Normally, integration tests use the release version of SNOwGLoBES that was
+installed as a dependency of SNEWPY. To use custom data files, set the
+``$SNOWGLOBES`` environment variable to the path of your SNOwGLoBES directory.
+
+Building Documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+SNEWPY uses `Sphinx <https://www.sphinx-doc.org/>`_ for documentation.
+See the Sphinx website for an `overview over the markup syntax <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_.
+First, to install the necessary packages, use::
+
+    pip install ".[docs]"
+    cd doc/
+
+You can then build the documentation and view it in your browser::
+
+    make html
+    open build/index.html
 
 Contribute Supernova Models
 ---------------------------
@@ -66,3 +79,10 @@ your contribution or simply `submit a pull request
 Ideally, your pull request should include a customized SupernovaModel subclass
 to read in your model files. See the code of existing models for examples or
 let us know in your issue or pull request if you need help.
+
+
+.. rubric:: Footnotes
+
+.. [#fn_fork] If you are a member of the SNEWS2 organization on GitHub, you
+    don’t need to create a fork; simply use ``git clone git@github.com:SNEWS2/snewpy.git`` instead.
+    In that case, please include your user name in the branch name for clarity.


### PR DESCRIPTION
Several improvements to the documentation pages and README:

* Improved instructions for how to contribute to and cite SNEWPY in the docs pages
* README now links to the docs page on how to contribute, rather than duplicating part of that content.
* Updates the README file with short sample code snippets to be more welcoming to new users

Thanks to @santosmv for suggesting the sample code snippets!