### PR TITLE
Update model downloader

### DIFF
--- a/python/snewpy/_model_downloader.py
+++ b/python/snewpy/_model_downloader.py
@@ -21,10 +21,11 @@ from snewpy import model_path
 from snewpy import __version__ as snewpy_version
 
 import logging
-logger = logging.getLogger('FileHandle')
+
+logger = logging.getLogger("FileHandle")
 
 
-def _md5(fname:str) -> str:
+def _md5(fname: str) -> str:
     """calculate the md5sum hash of a file."""
     hash_md5 = hashlib.md5()
     with open(fname, "rb") as f:
@@ -33,62 +34,70 @@ def _md5(fname:str) -> str:
     return hash_md5.hexdigest()
 
 
-def _download(src:str, dest:str, chunk_size=8192):
+def _download(src: str, dest: str, chunk_size=8192):
     """Download a file from 'src' to 'dest' and show the progress bar."""
-    #make sure parent dir exists
+    # make sure parent dir exists
     Path(dest).parent.mkdir(exist_ok=True, parents=True)
     with requests.get(src, stream=True) as r:
         r.raise_for_status()
-        fileSize = int(r.headers.get('content-length', 0))
-        with tqdm(desc=dest.name, total=fileSize, unit='iB', unit_scale=True, unit_divisor=1024) as bar:
-            with open(dest, 'wb') as f:
+        fileSize = int(r.headers.get("content-length", 0))
+        with tqdm(
+            desc=dest.name,
+            total=fileSize,
+            unit="iB",
+            unit_scale=True,
+            unit_divisor=1024,
+        ) as bar:
+            with open(dest, "wb") as f:
                 for chunk in r.iter_content(chunk_size=chunk_size):
                     size = f.write(chunk)
                     bar.update(size)
 
 
 class ChecksumError(FileNotFoundError):
-    """Raise an exception due to a mismatch in the MD5 checksum.
-    """
+    """Raise an exception due to a mismatch in the MD5 checksum."""
+
     def __init__(self, path, md5_exp, md5_actual):
-        super().__init__(f'Checksum error for file {path}: {md5_actual}!={md5_exp}')
+        super().__init__(f"Checksum error for file {path}: {md5_actual}!={md5_exp}")
+
     pass
 
 
 class MissingFileError(FileNotFoundError):
-    """Raise an exception due to a missing file.
-    """
+    """Raise an exception due to a missing file."""
+
     pass
 
 
 @dataclass
 class FileHandle:
     """Object storing local path, remote URL (optional), and MD5 sum
-(optional) for a SNEWPY model file. If the requested file is already present
-locally, open it. Otherwise, download it from the remote URL to the desired
-local path.
+    (optional) for a SNEWPY model file. If the requested file is already present
+    locally, open it. Otherwise, download it from the remote URL to the desired
+    local path.
     """
+
     path: Path
     remote: str = None
     md5: Optional[str] = None
-    
+
     def check(self) -> None:
         """Check if the given file exists locally and has a correct md5 sum.
         Raises
         ------
         :class:`MissingFileError`
             if the local copy of the file is missing
-        :class:`ChecksumError` 
+        :class:`ChecksumError`
             if the local file exists, but the checksum is wrong"""
         if not self.path.exists():
             raise MissingFileError(self.path)
         if self.md5:
-            logger.info(f'File {self.path}: checking md5')
+            logger.info(f"File {self.path}: checking md5")
             md5 = _md5(self.path)
-            logger.debug(f'{md5} vs expected {self.md5}')
-            if (md5 != self.md5):
+            logger.debug(f"{md5} vs expected {self.md5}")
+            if md5 != self.md5:
                 raise ChecksumError(self.path, self.md5, md5)
-    
+
     def load(self) -> Path:
         """Make sure that local file exists and has a correct checksum.
         Download the file if needed.
@@ -96,13 +105,13 @@ local path.
         try:
             self.check()
         except FileNotFoundError as e:
-            logger.info(f'Downloading file {self.path}')
+            logger.info(f"Downloading file {self.path}")
             _download(self.remote, self.path)
             self.check()
         return self.path
 
 
-def _from_zenodo(zenodo_id:str, filename:str):
+def _from_zenodo(zenodo_id: str, filename: str):
     """Access files on Zenodo.
 
     Parameters
@@ -114,22 +123,24 @@ def _from_zenodo(zenodo_id:str, filename:str):
     -------
     file_url, md5sum
     """
-    zenodo_url = f'https://zenodo.org/api/records/{zenodo_id}'
+    zenodo_url = f"https://zenodo.org/api/records/{zenodo_id}"
     record = requests.get(zenodo_url).json()
     # Search for file string in Zenodo request for this record.
-    file = next((_file for _file in record['files'] if _file['key'] == filename), None)
+    file = next((_file for _file in record["files"] if _file["key"] == filename), None)
 
     # If matched, return a tuple of URL and checksum.Otherwise raise an exception.
     if file is not None:
-        return file['links']['self'], file['checksum'].split(':')[1]
+        return file["links"]["self"], file["checksum"].split(":")[1]
     else:
         raise MissingFileError(filename)
-        
+
+
 class ModelRegistry:
     """Access model data. Configuration for each model is in a YAML file
-        distributed with SNEWPY.
+    distributed with SNEWPY.
     """
-    def __init__(self, config_file:Path = None, local_path: str = model_path):
+
+    def __init__(self, config_file: Path = None, local_path: str = model_path):
         """
         Parameters
         ----------
@@ -137,48 +148,55 @@ class ModelRegistry:
         local_path: local installation path (defaults to astropy cache).
         """
         if config_file is None:
-            context = open_text('snewpy.models', 'model_files.yml')
+            context = open_text("snewpy.models", "model_files.yml")
         else:
             context = open(config_file)
         with context as f:
             self.config = yaml.safe_load(f)
-        self.models = self.config['models']
+        self.models = self.config["models"]
         self.local_path = local_path
 
-    def get_file(self, config_path:str, filename:str)->Path:
+    def get_file(self, config_path: str, filename: str) -> Path:
         """Get the requested data file from the models file repository
 
         Parameters
         ----------
         config_path : dot-separated path of the model in the YAML configuration (e.g. "ccsn.Bollig_2016")
         filename : Name of simulation datafile, or a relative path from the model sub-directory
-    
+
         Returns
         -------
         Path of downloaded file.
         """
-        tokens = config_path.split('.')
+        tokens = config_path.split(".")
         config = self.models
         for t in tokens:
             config = config[t]
-        #store the model name
+        # store the model name
         model = tokens[-1]
-        modconf = config
         # Get data from GitHub or Zenodo.
-        repo = modconf['repository']
-        if repo == 'zenodo':
-            url, md5 = _from_zenodo(zenodo_id=config['zenodo_id'],filename=filename)
+        repo = config["repository"]
+        if repo == "zenodo":
+            url, md5 = _from_zenodo(zenodo_id=config["zenodo_id"], filename=filename)
         else:
-            #format the url directly
-            params = { 'model':model, 'filename':filename, 'snewpy_version':snewpy_version}
-            params.update(modconf) #default parameters can be overriden in the model config
+            # format the url directly
+            params = {
+                "model": model,
+                "filename": filename,
+                "snewpy_version": snewpy_version,
+            }
+            params.update(
+                config
+            )  # default parameters can be overriden in the model config
             url, md5 = repo.format(**params), None
-        localpath = Path(model_path)/str(model)
+        localpath = Path(model_path) / str(model)
         localpath.mkdir(exist_ok=True, parents=True)
-        fh = FileHandle(path = localpath/filename,remote = url, md5=md5)
+        fh = FileHandle(path=localpath / filename, remote=url, md5=md5)
         return fh.load()
 
+
 registry = ModelRegistry()
+
 
 def get_model_data(model: str, filename: str) -> Path:
     """Get the requested data file from the models file repository
@@ -196,4 +214,3 @@ def get_model_data(model: str, filename: str) -> Path:
         return Path(filename)
     else:
         return registry.get_file(model, filename)
-    

--- a/python/snewpy/_model_downloader.py
+++ b/python/snewpy/_model_downloader.py
@@ -179,3 +179,6 @@ class ModelRegistry:
         return fh.load()
 
 registry = ModelRegistry()
+
+def get_model_data(model: str, filename: str) -> Path:
+    return registry.get_file(filename, model)

--- a/python/snewpy/_model_downloader.py
+++ b/python/snewpy/_model_downloader.py
@@ -181,4 +181,15 @@ class ModelRegistry:
 registry = ModelRegistry()
 
 def get_model_data(model: str, filename: str) -> Path:
+    """Get the requested data file from the models file repository
+
+    Parameters
+    ----------
+    model : dot-separated path of the model in the YAML configuration (e.g. "ccsn.Bollig_2016")
+    filename : Name of simulation datafile, or a relative path from the model sub-directory
+
+    Returns
+    -------
+    Path of downloaded file.
+    """
     return registry.get_file(model, filename)

--- a/python/snewpy/_model_downloader.py
+++ b/python/snewpy/_model_downloader.py
@@ -186,10 +186,14 @@ def get_model_data(model: str, filename: str) -> Path:
     Parameters
     ----------
     model : dot-separated path of the model in the YAML configuration (e.g. "ccsn.Bollig_2016")
-    filename : Name of simulation datafile, or a relative path from the model sub-directory
+    filename : Absolute path to simulation datafile, or a relative path from the model sub-directory
 
     Returns
     -------
     Path of downloaded file.
     """
-    return registry.get_file(model, filename)
+    if os.path.isabs(filename):
+        return Path(filename)
+    else:
+        return registry.get_file(model, filename)
+    

--- a/python/snewpy/_model_downloader.py
+++ b/python/snewpy/_model_downloader.py
@@ -157,7 +157,7 @@ class ModelRegistry:
         -------
         Path of downloaded file.
         """
-        tokens = path.split('.')
+        tokens = config_path.split('.')
         config = self.models
         for t in tokens:
             config = config[t]
@@ -181,4 +181,4 @@ class ModelRegistry:
 registry = ModelRegistry()
 
 def get_model_data(model: str, filename: str) -> Path:
-    return registry.get_file(filename, model)
+    return registry.get_file(model, filename)


### PR DESCRIPTION
Mostly refactoring: same functionality, but using a more object-oriented approach.
1) Mostly refactoring: keeps the same functionality, calling `snewpy._model_downloader.get_model_data`
2) A global variable `registry` is defined and reused, so no need to read `model_files.yml` every time a model requests a file - it is read only once.
3) New feature: implements #269. This is not actually used now, but will be useful later, when we include preSN