### PR TITLE
Update Jupyter notebooks

### DIFF
--- a/models/Tamborra_2014/Tamborra_2014.ipynb
+++ b/models/Tamborra_2014/Tamborra_2014.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "## Initialize Models\n",
     "\n",
-    "To start, let’s see what progenitors are available for the `Tamborra_2014` model. We can use the `param` property to view all physics parameters and their possible values:"
+    "To start, let’s see what progenitors are available for the `Tamborra_2014` model. We can use the `param` property to view all physics parameters and their possible values. However, for this model, not all combinations of these parameters are valid, so we use the `get_param_combinations` function to get a list of all valid combinations:"
    ]
   },
   {
@@ -48,14 +48,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Tamborra_2014.param"
+    "# Tamborra_2014.param\n",
+    "Tamborra_2014.get_param_combinations()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We’ll initialise both of these progenitors. If this is the first time you’re using a progenitor, snewpy will automatically download the required data files for you."
+    "We’ll initialise two of these progenitors. If this is the first time you’re using a progenitor, snewpy will automatically download the required data files for you."
    ]
   },
   {
@@ -64,8 +65,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m20 = Tamborra_2014(progenitor_mass=20*u.solMass)\n",
-    "m27 = Tamborra_2014(progenitor_mass=27*u.solMass)\n",
+    "m20 = Tamborra_2014(progenitor_mass=20*u.solMass, direction=1)\n",
+    "m27 = Tamborra_2014(progenitor_mass=27*u.solMass, direction=1)\n",
     "\n",
     "m20"
    ]

--- a/models/Walk_2018/Walk_2018.ipynb
+++ b/models/Walk_2018/Walk_2018.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Walk_2018(progenitor_mass=15*u.solMass)\n",
+    "model = Walk_2018(progenitor_mass=15*u.solMass, rotation='fast', direction=1)\n",
     "\n",
     "model"
    ]

--- a/models/Walk_2019/Walk_2019.ipynb
+++ b/models/Walk_2019/Walk_2019.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "## Initialize Models\n",
     "\n",
-    "To start, let’s see what progenitors are available for the `Walk_2019` model. We can use the `param` property to view all physics parameters and their possible values:"
+    "To start, let’s see what progenitors are available for the `Walk_2019` model. We can use the `param` property to view all physics parameters and their possible values. However, for this model, not all combinations of these parameters are valid, so we use the `get_param_combinations` function to get a list of all valid combinations:"
    ]
   },
   {
@@ -48,7 +48,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Walk_2019.param"
+    "# Walk_2019.param\n",
+    "Walk_2019.get_param_combinations()"
    ]
   },
   {
@@ -64,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Walk_2019(progenitor_mass=40*u.solMass)\n",
+    "model = Walk_2019(progenitor_mass=40*u.solMass, direction=1)\n",
     "\n",
     "model"
    ]

--- a/python/snewpy/neutrino.py
+++ b/python/snewpy/neutrino.py
@@ -228,5 +228,5 @@ parameter_presets = {
 }
    
 
-def MixingParameters(mass_order:MassHierarchy=MassHierarchy.NORMAL, version:str='NuFIT5.0'):
-    return parameter_presets[version][mass_order]
+def MixingParameters(mh:MassHierarchy=MassHierarchy.NORMAL, version:str='NuFIT5.0'):
+    return parameter_presets[version][mh]


### PR DESCRIPTION
This fixes #277, #278 and #280.

The first two commits are just updating example notebooks to account for additional models we’ve added in v1.4.
The third one changes the name of an optional parameter to `MixingParameters` from `mass_order` back to `mh` (which it was in v1.3 and earlier). I’d like to release a v1.4.1 ASAP, to avoid anyone else running into issues with this.