### PR TITLE
Allow scalar input for 't', 'E' and 'data' arguments of Container class

### DIFF
--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -125,6 +125,21 @@ class _ContainerBase:
         self.energy = u.Quantity(energy, ndmin=1)
         self.flavor = np.sort(np.array(flavor, ndmin=1))
         
+        #list all valid shapes of the input array
+        Nf,Nt,Ne = len(self.flavor), len(self.time), len(self.energy)
+        expected_shapes=[(Nf,Nt,Ne), (Nf,Nt-1,Ne), (Nf,Nt,Ne-1), (Nf,Nt-1,Ne-1)]
+        
+        #treat special case if data is 1d array
+        if self.array.squeeze().ndim==1:
+            #try to reshape the array to expected shape
+            for expected_shape in expected_shapes:
+                if np.prod(expected_shape)==self.array.size:
+                    self.array = self.array.reshape(expected_shape)
+                    break
+        #validate the data array shape
+        if self.array.shape not in expected_shapes:
+            raise ValueError(f"Data array of shape {data.shape} is inconsistent with any valid shapes {expected_shapes}")
+        
         if integrable_axes is not None:
             #store which axes can be integrated
             self._integrable_axes = set(integrable_axes)

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -123,7 +123,7 @@ class _ContainerBase:
         self.array = u.Quantity(data, ndmin=3)
         self.time = u.Quantity(time, ndmin=1)
         self.energy = u.Quantity(energy, ndmin=1)
-        self.flavor = np.sort(flavor)
+        self.flavor = np.sort(np.array(flavor, ndmin=1))
         
         if integrable_axes is not None:
             #store which axes can be integrated

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -101,14 +101,14 @@ class _ContainerBase:
         data: :class:`astropy.Quantity`
             3D array of the stored quantity, must have dimensions compatible with (flavor, time, energy)
         
-        flavor: list of :class:`snewpy.neutrino.Flavor`
+        flavor: list or a single value of :class:`snewpy.neutrino.Flavor`
             array of flavors (should be ``len(flavor)==data.shape[0]``
         
-        time: array of :class:`astropy.Quantity`
+        time: :class:`astropy.Quantity`
             sampling points in time (then ``len(time)==data.shape[1]``) 
             or time bin edges (then ``len(time)==data.shape[1]+1``) 
     
-        energy: array of :class:`astropy.Quantity`
+        energy: :class:`astropy.Quantity`
             sampling points in energy (then ``len(energy)=data.shape[2]``) 
             or energy bin edges (then ``len(energy)=data.shape[2]+1``) 
     

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -119,10 +119,11 @@ class _ContainerBase:
         if self.unit is not None:
             #try to convert to the unit
             data = data.to(self.unit)
-        self.array = data
+        #convert the input values to arrays if they are scalar
+        self.array = u.Quantity(data, ndmin=3)
+        self.time = u.Quantity(time, ndmin=1)
+        self.energy = u.Quantity(energy, ndmin=1)
         self.flavor = np.sort(flavor)
-        self.time = time
-        self.energy = energy
         
         if integrable_axes is not None:
             #store which axes can be integrated

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -120,17 +120,16 @@ class _ContainerBase:
             #try to convert to the unit
             data = data.to(self.unit)
         #convert the input values to arrays if they are scalar
-        self.array = u.Quantity(data, ndmin=3)
+        self.array = u.Quantity(data)
         self.time = u.Quantity(time, ndmin=1)
         self.energy = u.Quantity(energy, ndmin=1)
         self.flavor = np.sort(np.array(flavor, ndmin=1))
         
-        #list all valid shapes of the input array
         Nf,Nt,Ne = len(self.flavor), len(self.time), len(self.energy)
-        expected_shapes=[(Nf,Nt,Ne), (Nf,Nt-1,Ne), (Nf,Nt,Ne-1), (Nf,Nt-1,Ne-1)]
-        
+        #list all valid shapes of the input array
+        expected_shapes=[(nf,nt,ne) for nf in (Nf,Nf-1) for nt in (Nt,Nt-1) for ne in (Ne,Ne-1)]
         #treat special case if data is 1d array
-        if self.array.squeeze().ndim==1:
+        if self.array.ndim==1:
             #try to reshape the array to expected shape
             for expected_shape in expected_shapes:
                 if np.prod(expected_shape)==self.array.size:

--- a/python/snewpy/test/test_flux_container.py
+++ b/python/snewpy/test/test_flux_container.py
@@ -59,12 +59,18 @@ def test_construction_succesfull(flavor, energy, time, unit):
     assert Container[unit](data, flavor, time, energy)
 
 @given(flavor=flavors, time=times, energy=energies, unit=units)
-def test_construction_with_wrong_units_raises_ValueError(flavor, energy, time, unit):
+def test_construction_with_wrong_units_raises_ConversionError(flavor, energy, time, unit):
     data = np.ones([len(flavor),len(time), len(energy)])<<unit
     with pytest.raises(u.UnitConversionError):
         Container[unit*u.kg](data, flavor, time, energy)
     with pytest.raises(u.UnitConversionError):
         Container[unit](data*u.kg, flavor, time, energy)
+
+@given(flavor=flavors, time=times, energy=energies, unit=units)
+def test_construction_with_wrong_dimensions_raises_ValueError(flavor, energy, time, unit):
+    data = np.ones([len(flavor)+1,len(time), len(energy)])<<unit
+    with pytest.raises(ValueError):
+        Container[unit](data, flavor, time, energy)
 
 @given(f=random_flux_containers())
 def test_summation_over_flavor(f:Container):


### PR DESCRIPTION
Fixing problem if a user passes a scalar value to container. 
Example:
```python
import numpy as np
import astropy.units as u
from snewpy.flux import Flux
from snewpy.neutrino import Flavor

# this was the only valid way before this fix: wrap everything in []
Flux(data = [1] << u.Unit('1/(MeV s cm**2)'), 
     flavor=[Flavor.NU_E],
     time=[1]<<u.s,
     energy=[1]<<u.MeV)

#now it's possible to pass scalars if there is only a single value or point
Flux(data = 1 << u.Unit('1/(MeV s cm**2)'), 
     flavor=Flavor.NU_E, 
     time=1<<u.s,
     energy=1<<u.MeV)

#they're converted internally to arrays. This produces 
# d2FdEdT (1, 1, 1) [1 / (MeV s m2)]: <1 flavor(0;0) x 1 time(1.0 s;1.0 s) x 1 energy(1.0 MeV;1.0 MeV)>
```