### PR TITLE
times broadcasting for Fornax_2021

### DIFF
--- a/python/snewpy/models/loaders.py
+++ b/python/snewpy/models/loaders.py
@@ -687,16 +687,17 @@ class Fornax_2021(SupernovaModel):
 
             elif interpolation.lower() == 'nearest':
                 # Find edges of energy bins and identify which energy bin (each entry of) E falls into
-                _logEbinEdges = _logE - _dlogE[0] / 2
-                _logEbinEdges = np.concatenate((_logEbinEdges, [_logE[-1] + _dlogE[-1] / 2]))
+                _logEbinEdges = _logE - _dlogE[0,0] / 2
+                _logEbinEdges = np.append(_logEbinEdges, np.expand_dims(_logE[:,-1] + _dlogE[:,-1]/2, 1), axis=1)
                 _EbinEdges = 10**_logEbinEdges
-                idx = np.searchsorted(_EbinEdges, E) - 1
-                select = (idx > 0) & (idx < len(_E))
+                idx = np.array([np.searchsorted(edges, E) - 1 for edges in _EbinEdges])
+                select = np.array([(_idx > 0) & (_idx < len(__E)) for _idx, __E in zip(idx, _E)])
 
                 # Divide luminosity spectrum by energy at bin center to get number luminosity spectrum
-                _dNLdE = np.zeros(len(E))
-                _dNLdE[np.where(select)] = np.asarray(
-                    [self._dLdE[flavor]['g{}'.format(i)][j] / _E[i] for i in idx[select]])
+                _dNLdE = np.zeros([len(j), len(np.atleast_1d(E))])
+                for i in range(len(j)):
+                    _dNLdE[i][np.where(select[i])] = np.asarray([self._dLdE[flavor]['g{}'.format(ebin_idx)][j[i]] / _E[i][ebin_idx]
+                                                                 for ebin_idx in idx[i][select[i]]])
                 initialspectra[flavor] = ((_dNLdE << 1/u.MeV) * factor * 1e50 * u.erg/u.s/u.MeV).to('1 / (erg s)')
 
             else:

--- a/python/snewpy/models/loaders.py
+++ b/python/snewpy/models/loaders.py
@@ -659,8 +659,8 @@ class Fornax_2021(SupernovaModel):
 
         # Make sure the input time uses the same units as the model time grid.
         # Convert input time to a time index.
-        t = t.to(self.time.unit)
-        j = (np.abs(t - self.time)).argmin()
+        t = u.Quantity(t.to(self.time.unit), ndmin=1)
+        j = np.array(list(np.abs(_t - self.time).argmin() for _t in t))
 
         for flavor in flavors:
             # Energy bin centers (in MeV)
@@ -675,14 +675,15 @@ class Fornax_2021(SupernovaModel):
             # Linear interpolation in flux.
             if interpolation.lower() == 'linear':
                 # Pad log(E) array with values where flux is fixed to zero.
-                _logEbins = np.insert(_logE, 0, np.log10(np.finfo(float).eps * E.unit/u.MeV))
-                _logEbins = np.append(_logEbins, _logE[-1] + _dlogE[-1])
+                _logEbins = np.insert(_logE, 0, np.log10(np.finfo(float).eps * E.unit/u.MeV), axis=1)
+                _logEbins = np.append(_logEbins, np.expand_dims(_logE[:,-1] + _dlogE[:,-1], 1), axis=1)
 
                 # Luminosity spectrum _dLdE is in units of 1e50 erg/s/MeV.
                 # Pad with values where flux is fixed to zero, then divide by E to get number luminosity
-                _dNLdE = np.asarray([0.] + [self._dLdE[flavor]['g{}'.format(i)][j] for i in range(12)] + [0.])
-                initialspectra[flavor] = (np.interp(logE, _logEbins, _dNLdE) / E *
-                                          factor * 1e50 * u.erg/u.s/u.MeV).to('1 / (erg s)')
+                _dNLdE = np.asarray([np.zeros(j.shape)] + [self._dLdE[flavor]['g{}'.format(i)][j] for i in range(12)] + [np.zeros(j.shape)]).T
+                interp_values = np.array([np.interp(logE, __logEbins, __dNLdE)
+                                          for __logEbins, __dNLdE in zip(_logEbins, _dNLdE)])
+                initialspectra[flavor] = (interp_values / E * factor * 1e50 * u.erg/u.s/u.MeV).to('1 / (erg s)')
 
             elif interpolation.lower() == 'nearest':
                 # Find edges of energy bins and identify which energy bin (each entry of) E falls into


### PR DESCRIPTION
Fixes #259.
Additionally fixes a bug I discovered during this work, where for `interpolation="nearest"` a scalar value for E (e.g. `10*u.MeV`) would crash and a length-1 array (e.g. `[10]*u.MeV`) was required instead.

In addition to the usual tests, I’ve verified manually that the outputs for a few example t/E values were unchanged before/after this change. Additionally, I ran some performance checks, comparing the old and new versions with the following code snippet:

```Python
from snewpy.neutrino import Flavor
from snewpy.models.ccsn import Fornax_2021
from astropy import units as u
import numpy as np

fornax = Fornax_2021(progenitor_mass=Fornax_2021.param['progenitor_mass'][1])
n_times = 100  # set this to 1, 10, 100 for benchmarking
times = np.linspace(1, 2, n_times) * u.s

# old: manually loop over times
for t in times:
    fornax.get_initial_spectra(t=t, E=list(range(100))*u.MeV, flavors=[Flavor.NU_E], interpolation="nearest")[Flavor.NU_E]

# this PR
fornax.get_initial_spectra(t=times, E=list(range(100))*u.MeV, flavors=[Flavor.NU_E], interpolation="nearest")[Flavor.NU_E]
```

Overall, this PR adds about ~10% overhead for a single time value, but for multiple time values it grows much less than linearly, so we’d see a performance boost for two or more time values, with about an order of magnitude better performance for 100 time values.

**Benchmark results for `interpolation = "linear"`**
Here, the length of the energies array passed in had no significant impact on results.

| `n_times` | old | this PR |
|--------|-----|-----|
| 1 | 0.62 ms | 0.69 ms |
| 10 | 6.2 ms | 1.2 ms |
| 100 | 61 ms | 5.5 ms |

**Benchmark results for `interpolation = "nearest"`**
Here, the range in each cell shows the impact of using an energy array of length 1–100 for a given `n_times`.
There’s likely some room for improvement here (as you’ll see in the diff, for one line I gave up and used a for loop over times, rather than spending even more time trying to figure out how to use NumPy broadcasting), especially for large arrays of energies and times; but this PR still a major improvement over the status quo and I don’t think it’s worth investing more time into this. (`interpolation = "nearest"` is a non-default value with little physics motivation; I doubt it’s used much.)

| `n_times` | old | this PR |
|--------|-----|-----|
| 1 | 0.55 – 0.65 ms | 0.59 – 0.70 ms |
| 10 | 5.1 – 6.2 ms | 0.97 – 2.0 ms |
| 100 | 51 – 61 ms | 4.3 – 15 ms |
