### PR TITLE
Mori_2023: don’t duplicate metadata dict entries into instance variables

### DIFF
--- a/python/snewpy/models/ccsn_loaders.py
+++ b/python/snewpy/models/ccsn_loaders.py
@@ -826,11 +826,6 @@ class Mori_2023(PinchedModel):
         """
         # Open the requested filename using the model downloader.
         datafile = self.request_file(filename)
-        # Set up model metadata
-        self.axion_mass = metadata['Axion mass']
-        self.axion_coupling = metadata['Axion coupling']
-        self.progenitor_mass = metadata['Progenitor mass']
-        self.pns_mass = metadata['PNS mass']
 
         self.metadata = metadata
 


### PR DESCRIPTION
Resolves #316 (the second part), see discussion there.