### PR TITLE
Adding the implementation of the FlavorScheme and FlavorMatrix

### DIFF
--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -1,11 +1,6 @@
-def MakeFlavorScheme(name:str, leptons:list[str]):
-    return enum.Enum(name, start=0, type=FlavorScheme,
-                   names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']]
-                  )
-
-TwoFlavor = MakeFlavorScheme('TwoFlavor',['E','X'])
-ThreeFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU'])
-FourFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU','S'])
+import enum
+import numpy as np
+import typing
 
 class FlavorScheme:
     def to_tex(self):
@@ -66,9 +61,9 @@ def _makeFlavorScheme(name:str, leptons:list[str]):
                    names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']]
                   )
 
-TwoFlavor = MakeFlavorScheme('TwoFlavor',['E','X'])
-ThreeFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU'])
-FourFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU','S'])
+TwoFlavor = _makeFlavorScheme('TwoFlavor',['E','X'])
+ThreeFlavor = _makeFlavorScheme('ThreeFlavor',['E','MU','TAU'])
+FourFlavor = _makeFlavorScheme('ThreeFlavor',['E','MU','TAU','S'])
 
 
 class FlavorMatrix:

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -5,9 +5,13 @@ import typing
 class FlavorScheme:
     def to_tex(self):
         """LaTeX-compatible string representations of flavor."""
+        base = r'\nu'
         if self.is_antineutrino:
-            return r'$\overline{{\nu}}_{0}$'.format(self.name[3].lower())
-        return r'$\{0}$'.format(self.name.lower())
+            base = r'\overline{\nu}'
+        lepton = self.lepton.lower()
+        if self.is_muon or self.is_tauon:
+            lepton = f"\{lepton}"
+        return f"${base}_{{{lepton}}}$"
 
     @classmethod
     def _to_value(cls,key)->int:
@@ -93,7 +97,7 @@ class FlavorMatrix:
         return self.array[self._convert_index(index)]
         
     def __setitem__(self, index, value):
-        self.array[self._convert_index(index)]=value
+        self.array[self._convert_index(index)] = value
         
     def __repr__(self):
         s = f'{self.__class__.__name__}:<{self.flavors1.__name__}->{self.flavors2.__name__}>:'

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -21,7 +21,8 @@ class EnumMeta(enum.EnumMeta):
                         f'Cannot find key "{key}" in {cls.__name__} sheme! Valid options are {list(cls)}'
                     )
         
-        #if this is an int value: find a matching
+        #if this is anything else - treat it as a slice
+        return np.array(list(cls.__members__.values()),dtype=object)[key]
 
 class FlavorScheme(enum.IntEnum, metaclass=EnumMeta):
     def to_tex(self):
@@ -66,6 +67,9 @@ class FlavorScheme(enum.IntEnum, metaclass=EnumMeta):
     def from_lepton_names(cls, name:str, leptons:list):
         enum_class =  cls(name, start=0, names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']])
         return enum_class
+    @classmethod
+    def take(cls, index):
+        return cls[index]
 
 TwoFlavor = FlavorScheme.from_lepton_names('TwoFlavor',['E','X'])
 ThreeFlavor = FlavorScheme.from_lepton_names('ThreeFlavor',['E','MU','TAU'])

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -156,25 +156,18 @@ class FlavorMatrix:
     #flavor conversion utils
     
 def conversion_matrix(from_flavor:FlavorScheme, to_flavor:FlavorScheme):
-    if(from_flavor==TwoFlavor):
-        #define special cases
-        @FlavorMatrix.from_function(to_flavor, from_flavor)
-        def convert_2toN(f1,f2):
-            if (f1.name==f2.name):
-                return 1.
-            if (f1.is_neutrino==f2.is_neutrino)and(f2.lepton=='X' and f1.lepton in ['MU','TAU']):
-                return 1.
-            return 0
-        return convert_2toN
-    else:
-        @FlavorMatrix.from_function(to_flavor, from_flavor)
-        def convert_Nto2(f1,f2):
-            if (f1.name==f2.name):
-                return 1.
-            if (f1.is_neutrino==f2.is_neutrino)and(f1.lepton=='X' and f2.lepton in ['MU','TAU']):
-                return 0.5
-            return 0.
-        return convert_Nto2
+    @FlavorMatrix.from_function(to_flavor, from_flavor)
+    def convert(f1, f2):
+        if f1.name == f2.name:
+            return 1.
+        if (f1.is_neutrino == f2.is_neutrino) and (f2.lepton == 'X' and f1.lepton in ['MU', 'TAU']):
+            # convert from TwoFlavor to more flavors
+            return 1.
+        if (f1.is_neutrino == f2.is_neutrino) and (f1.lepton == 'X' and f2.lepton in ['MU', 'TAU']):
+            # convert from more flavors to TwoFlavor
+            return 0.5
+        return 0.
+    return convert
 
 FlavorScheme.conversion_matrix = classmethod(conversion_matrix)
 EnumMeta.__rshift__ = conversion_matrix

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -1,0 +1,123 @@
+def MakeFlavorScheme(name:str, leptons:list[str]):
+    return enum.Enum(name, start=0, type=FlavorScheme,
+                   names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']]
+                  )
+
+TwoFlavor = MakeFlavorScheme('TwoFlavor',['E','X'])
+ThreeFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU'])
+FourFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU','S'])
+
+class FlavorScheme:
+    def to_tex(self):
+        """LaTeX-compatible string representations of flavor."""
+        if self.is_antineutrino:
+            return r'$\overline{{\nu}}_{0}$'.format(self.name[3].lower())
+        return r'$\{0}$'.format(self.name.lower())
+
+    @classmethod
+    def to_value(cls,key)->int:
+        if isinstance(key, str):
+            try:
+                return cls[key].value
+            except KeyError as e:
+                raise KeyError(
+                    f'Cannot find key "{key}" in {cls.__name__} sheme! Valid options are {list(cls)}'
+                )
+        elif isinstance(key, FlavorScheme):
+            if not isinstance(key, cls):
+                raise TypeError(f'Value {repr(key)} is not from {cls.__name__} sheme!')
+            return key.value
+        return key
+        
+    @property
+    def is_neutrino(self):
+        return not self.is_antineutrino
+
+    @property
+    def is_antineutrino(self):
+        return '_BAR' in self.name
+
+    @property
+    def is_electron(self):
+        """Return ``True`` for ``TwoFlavor.NU_E`` and ``TwoFlavor.NU_E_BAR``."""
+        return self.lepton=='E'
+
+    @property
+    def is_muon(self):
+        """Return ``True`` for ``TwoFlavor.NU_E`` and ``TwoFlavor.NU_E_BAR``."""
+        return self.lepton=='MU'
+
+    @property
+    def is_tauon(self):
+        """Return ``True`` for ``TwoFlavor.NU_E`` and ``TwoFlavor.NU_E_BAR``."""
+        return self.lepton=='TAU'
+
+    @property
+    def is_sterile(self):
+        return self.lepton=='S'
+        
+    @property
+    def lepton(self):
+        return self.name.split('_')[1]
+    
+
+def _makeFlavorScheme(name:str, leptons:list[str]):
+    return enum.Enum(name, start=0, type=FlavorScheme,
+                   names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']]
+                  )
+
+TwoFlavor = MakeFlavorScheme('TwoFlavor',['E','X'])
+ThreeFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU'])
+FourFlavor = MakeFlavorScheme('ThreeFlavor',['E','MU','TAU','S'])
+
+
+class FlavorMatrix:
+    def __init__(self, 
+                 array:np.ndarray,
+                 flavors:FlavorScheme,
+                 flavors2:FlavorScheme|None = None
+                ):
+                    self.array = np.asarray(array)
+                    self.flavors1 = flavors
+                    self.flavors2 = flavors2 or flavors
+                    assert self.array.shape == (len(self.flavors2), len(self.flavors1))
+
+    def _convert_index(self, index):
+        if isinstance(index, str) or (not isinstance(index,typing.Iterable)):
+            index = [index]
+        new_idx = [flavors.to_value(idx) for idx,flavors in zip(index, [self.flavors2,self.flavors1])]
+        print(new_idx)
+        return tuple(new_idx)
+        
+    def __getitem__(self, index):
+        return self.array[self._convert_index(index)]
+        
+    def __setitem__(self, index, value):
+        self.array[self._convert_index(index)]=value
+        
+    def __repr__(self):
+        s = f'{self.__class__.__name__}:<{self.flavors1.__name__}->{self.flavors2.__name__}>:'
+        s+='\n'+repr(self.array)
+        return s
+    #methods for creating matrix
+    @classmethod
+    def zeros(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None):
+        flavors2 = flavors2 or flavors1
+        shape = (len(flavors2), len(flavors1))
+        data = np.zeros(shape)
+        return cls(data, flavors1, flavors2)
+        
+    @classmethod
+    def eye(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None):
+        flavors2 = flavors2 or flavors1
+        shape = (len(flavors2), len(flavors1))
+        data = np.eye(*shape)
+        return cls(data, flavors1, flavors2)
+        
+    @classmethod
+    def identity(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None):
+        flavors2 = flavors2 or flavors1
+        data = [[f1.name==f2.name 
+                 for f1 in flavors1]
+                for f2 in flavors2]
+        return cls(np.array(data,dtype=float), flavors1, flavors2)

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -77,7 +77,7 @@ class FlavorMatrix:
     def __init__(self, 
                  array:np.ndarray,
                  flavors:FlavorScheme,
-                 flavors2:FlavorScheme|None = None
+                 flavors2:FlavorScheme = None
                 ):
                     self.array = np.asarray(array)
                     self.flavors1 = flavors
@@ -112,28 +112,28 @@ class FlavorMatrix:
         
     #methods for creating matrix
     @classmethod
-    def zeros(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None):
+    def zeros(cls, flavors1:FlavorScheme, flavors2:FlavorScheme = None):
         flavors2 = flavors2 or flavors1
         shape = (len(flavors2), len(flavors1))
         data = np.zeros(shape)
         return cls(data, flavors1, flavors2)
         
     @classmethod
-    def eye(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None):
+    def eye(cls, flavors1:FlavorScheme, flavors2:FlavorScheme = None):
         flavors2 = flavors2 or flavors1
         shape = (len(flavors2), len(flavors1))
         data = np.eye(*shape)
         return cls(data, flavors1, flavors2)
 
     @classmethod
-    def from_function(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None, *, function):
+    def from_function(cls, flavors1:FlavorScheme, flavors2:FlavorScheme = None, *, function):
         flavors2 = flavors2 or flavors1
         data = [[function(f1,f2)
                  for f1 in flavors1]
                 for f2 in flavors2]
         return cls(np.array(data,dtype=float), flavors1, flavors2)
     @classmethod
-    def identity(cls, flavors1:FlavorScheme, flavors2:FlavorScheme|None = None):
+    def identity(cls, flavors1:FlavorScheme, flavors2:FlavorScheme = None):
         return cls.from_function(flavors1, flavors2, lambda f1,f2: 1.*(f1.name==f2.name))
 
 
@@ -160,3 +160,4 @@ def convert_2to3(f1,f2):
     if (f1.is_neutrino==f2.is_neutrino)and(f1.lepton=='X' and f2.lepton in ['MU','TAU']):
         return 1
     return 0
+

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -10,7 +10,7 @@ class FlavorScheme:
             base = r'\overline{\nu}'
         lepton = self.lepton.lower()
         if self.is_muon or self.is_tauon:
-            lepton = f"\{lepton}"
+            lepton = '\\'+lepton
         return f"${base}_{{{lepton}}}$"
 
     @classmethod

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -156,7 +156,6 @@ class FlavorMatrix:
     #flavor conversion utils
     
 def conversion_matrix(from_flavor:FlavorScheme, to_flavor:FlavorScheme):
-    print(from_flavor, to_flavor)
     if(from_flavor==TwoFlavor):
         #define special cases
         @FlavorMatrix.from_function(to_flavor, from_flavor)

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -163,7 +163,7 @@ def conversion_matrix(from_flavor:FlavorScheme, to_flavor:FlavorScheme):
             if (f1.name==f2.name):
                 return 1.
             if (f1.is_neutrino==f2.is_neutrino)and(f2.lepton=='X' and f1.lepton in ['MU','TAU']):
-                return 0.5
+                return 1.
             return 0
         return convert_2toN
     else:
@@ -172,7 +172,7 @@ def conversion_matrix(from_flavor:FlavorScheme, to_flavor:FlavorScheme):
             if (f1.name==f2.name):
                 return 1.
             if (f1.is_neutrino==f2.is_neutrino)and(f1.lepton=='X' and f2.lepton in ['MU','TAU']):
-                return 1.
+                return 0.5
             return 0.
         return convert_Nto2
 

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -117,7 +117,8 @@ class FlavorMatrix:
                 return FlavorMatrix(data, self.flavor_out, from_flavor = other.flavor_in)
             except Exception as e:
                 raise ValueError(f"Cannot multiply {self._repr_short()} by {other._repr_short()}") from e
-                
+        elif hasattr(other, '__rmatmul__'):
+            return other.__rmatmul__(self)        
         raise TypeError(f"Cannot multiply object of {self.__class__} by {other.__class__}")
     #properties
     @property

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -62,7 +62,7 @@ class FlavorScheme:
         return self.name.split('_')[1]
     
 
-def _makeFlavorScheme(name:str, leptons:list[str]):
+def _makeFlavorScheme(name:str, leptons:list):
     enum_class =  enum.IntEnum(name, start=0, type=FlavorScheme,
                    names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']]
                   )

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -10,7 +10,7 @@ class FlavorScheme:
         return r'$\{0}$'.format(self.name.lower())
 
     @classmethod
-    def to_value(cls,key)->int:
+    def _to_value(cls,key)->int:
         if isinstance(key, str):
             try:
                 return cls[key].value
@@ -22,6 +22,8 @@ class FlavorScheme:
             if not isinstance(key, cls):
                 raise TypeError(f'Value {repr(key)} is not from {cls.__name__} sheme!')
             return key.value
+        elif isinstance(key, typing.Iterable):
+            return tuple(map(cls._to_value, key))
         return key
         
     @property
@@ -57,9 +59,10 @@ class FlavorScheme:
     
 
 def _makeFlavorScheme(name:str, leptons:list[str]):
-    return enum.Enum(name, start=0, type=FlavorScheme,
+    enum_class =  enum.IntEnum(name, start=0, type=FlavorScheme,
                    names = [f'NU_{L}{BAR}' for L in leptons for BAR in ['','_BAR']]
                   )
+    return enum_class
 
 TwoFlavor = _makeFlavorScheme('TwoFlavor',['E','X'])
 ThreeFlavor = _makeFlavorScheme('ThreeFlavor',['E','MU','TAU'])
@@ -82,7 +85,7 @@ class FlavorMatrix:
     def _convert_index(self, index):
         if isinstance(index, str) or (not isinstance(index,typing.Iterable)):
             index = [index]
-        new_idx = [flavors.to_value(idx) for idx,flavors in zip(index, [self.flavors2,self.flavors1])]
+        new_idx = [flavors._to_value(idx) for idx,flavors in zip(index, [self.flavors2,self.flavors1])]
         print(new_idx)
         return tuple(new_idx)
         

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -52,8 +52,8 @@ Reference
 
 """
 from typing import Union, Optional, Set, List
-from snewpy.neutrino import Flavor
-from snewpy.flavor import FlavorScheme
+#from snewpy.neutrino import Flavor
+from snewpy.flavor import FlavorScheme, FlavorMatrix
 from astropy import units as u
 
 import numpy as np
@@ -344,6 +344,9 @@ class _ContainerBase:
         axes = list(self.axes)
         return Container(array, *axes)
 
+    def __rmatmul__(self, matrix:FlavorMatrix) -> 'Container':
+        
+        
     def save(self, fname:str)->None:
         """Save container data to a given file (using `numpy.savez`)"""
         def _save_quantity(name):

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -374,7 +374,7 @@ class _ContainerBase:
         result = self.__class__==other.__class__ and \
                  self.unit == other.unit and \
                  np.allclose(self.array, other.array) and \
-                 all(self.flavor==other.flavor) and \ 
+                 all(self.flavor==other.flavor) and \
                  all([np.allclose(self.axes[ax], other.axes[ax]) for ax in list(Axes)[1:]])
         return result
 

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -131,8 +131,9 @@ class _ContainerBase:
         self.flavor_scheme = flavor_scheme
         if not flavor_scheme:
             #guess the flavor scheme
-            if isinstance(flavor, type) and issubclass(flavor, FlavorScheme):
-                self.flavor_scheme = flavor
+            if isinstance(flavor, type):#issubclass without isinstance(type) check raises TypeError
+                if issubclass(flavor, FlavorScheme): 
+                    self.flavor_scheme = flavor
             else:
                 #get schemes from the data
                 flavor_schemes = set(f.__class__ for f in self.flavor)

--- a/python/snewpy/models/base.py
+++ b/python/snewpy/models/base.py
@@ -190,8 +190,8 @@ class SupernovaModel(ABC, LocalFileLoader):
         factor = 1/(4*np.pi*(distance.to('cm'))**2)
         f = self.get_transformed_spectra(t, E, flavor_xform)
 
-        array = np.stack([f[flv] for flv in sorted(Flavor)])
-        return  Flux(data=array*factor, flavor=np.sort(Flavor), time=t, energy=E)
+        array = np.stack([f[flv] for flv in Flavor])
+        return  Flux(data=array*factor, flavor=Flavor, time=t, energy=E)
 
 
 

--- a/python/snewpy/neutrino.py
+++ b/python/snewpy/neutrino.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Optional
 import numpy as np
 from collections.abc import Mapping
+from .flavor import TwoFlavor as Flavor
 
 class MassHierarchy(IntEnum):
     """Neutrino mass ordering: ``NORMAL`` or ``INVERTED``."""
@@ -23,32 +24,6 @@ class MassHierarchy(IntEnum):
         else:
             return MassHierarchy.INVERTED
             
-class Flavor(IntEnum):
-    """Enumeration of CCSN Neutrino flavors."""
-    NU_E = 0
-    NU_X = 1
-    NU_E_BAR = 2
-    NU_X_BAR = 3
-    
-    def to_tex(self):
-        """LaTeX-compatible string representations of flavor."""
-        if '_BAR' in self.name:
-            return r'$\overline{{\nu}}_{0}$'.format(self.name[3].lower())
-        return r'$\{0}$'.format(self.name.lower())
-
-    @property
-    def is_electron(self):
-        """Return ``True`` for ``Flavor.NU_E`` and ``Flavor.NU_E_BAR``."""
-        return self.value in (Flavor.NU_E.value, Flavor.NU_E_BAR.value)
-
-    @property
-    def is_neutrino(self):
-        """Return ``True`` for ``Flavor.NU_E`` and ``Flavor.NU_X``."""
-        return self.value in (Flavor.NU_E.value, Flavor.NU_X.value)
-
-    @property
-    def is_antineutrino(self):
-        return self.value in (Flavor.NU_E_BAR.value, Flavor.NU_X_BAR.value)
         
 @dataclass
 class MixingParameters3Flavor(Mapping):

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -1,7 +1,9 @@
 import pytest
 import numpy as np
-from snewpy import flavor
-from snewpy.flavor import TwoFlavor,ThreeFlavor,FourFlavor
+import snewpy.flavor
+from snewpy.flavor import TwoFlavor,ThreeFlavor,FourFlavor, FlavorMatrix, FlavorScheme
+
+flavor_schemes = TwoFlavor,ThreeFlavor,FourFlavor
 
 class TestFlavorScheme:
     @staticmethod
@@ -11,6 +13,7 @@ class TestFlavorScheme:
         assert len(FourFlavor)==8
         
     @staticmethod
+    
     def test_getitem_string():
         assert TwoFlavor['NU_E'] == TwoFlavor.NU_E
         assert TwoFlavor['NU_X'] == TwoFlavor.NU_X
@@ -31,7 +34,7 @@ class TestFlavorScheme:
     
     @staticmethod
     def test_makeFlavorScheme():
-        TestFlavor = flavor.makeFlavorScheme('TestFlavor',['A','B','C'])
+        TestFlavor = FlavorScheme.from_lepton_names('TestFlavor',leptons=['A','B','C'])
         assert len(TestFlavor)==6
         assert [f.name for f in TestFlavor]==['NU_A','NU_A_BAR','NU_B','NU_B_BAR','NU_C','NU_C_BAR']
 
@@ -82,16 +85,31 @@ class TestFlavorScheme:
 class TestFlavorMatrix:
     @staticmethod
     def test_init_square_matrix():
-        m = flavor.FlavorMatrix(array=np.ones(shape=(4,4)), flavors=TwoFlavor)
+        m = FlavorMatrix(array=np.ones(shape=(4,4)), flavor=TwoFlavor)
         assert m.shape == (4,4)
-        assert m.flavors_from == TwoFlavor
-        assert m.flavors_to == TwoFlavor
+        assert m.flavor_in == TwoFlavor
+        assert m.flavor_out == TwoFlavor
         
     @staticmethod
     def test_init_square_matrix_with_wrong_shape_raises_ValueError():
         with pytest.raises(ValueError):
-            m = flavor.FlavorMatrix(array=np.ones(shape=(4,5)), flavors=TwoFlavor)
+            m = FlavorMatrix(array=np.ones(shape=(4,5)), flavor=TwoFlavor)
         with pytest.raises(ValueError):
-            m = flavor.FlavorMatrix(array=np.ones(shape=(5,5)), flavors=TwoFlavor)
+            m = FlavorMatrix(array=np.ones(shape=(5,5)), flavor=TwoFlavor)
         with pytest.raises(ValueError):
-            m = flavor.FlavorMatrix(array=np.ones(shape=(5,4)), flavors=TwoFlavor)
+            m = FlavorMatrix(array=np.ones(shape=(5,4)), flavor=TwoFlavor)
+
+    @staticmethod
+    def test_conversion_matrices_for_same_flavor_are_unity():
+        for flavor in [TwoFlavor,ThreeFlavor,FourFlavor]:
+            matrix = FlavorMatrix.conversion_matrix(flavor,flavor)
+            print(matrix)
+            assert np.allclose(matrix.array, np.eye(len(flavor)))
+
+    @staticmethod
+    @pytest.mark.parametrize('flavor_in',flavor_schemes)
+    @pytest.mark.parametrize('flavor_out',flavor_schemes)
+    def test_conversion_matrices(flavor_in, flavor_out):
+        M = FlavorMatrix.conversion_matrix(flavor_out,flavor_in)
+        assert M.flavor_in == flavor_in
+        assert M.flavor_out == flavor_out

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+from snewpy import flavor
+from snewpy.flavor import TwoFlavor,ThreeFlavor,FourFlavor
+
+class TestFlavorScheme:
+    @staticmethod
+    def test_flavor_scheme_lengths():
+        assert len(TwoFlavor)==4
+        assert len(ThreeFlavor)==6
+        assert len(FourFlavor)==8
+        
+    @staticmethod
+    def test_getitem_string():
+        assert TwoFlavor['NU_E'] == TwoFlavor.NU_E
+        assert TwoFlavor['NU_X'] == TwoFlavor.NU_X
+        with pytest.raises(KeyError):
+            TwoFlavor['NU_MU']
+            
+    @staticmethod
+    def test_getitem_enum():
+        assert TwoFlavor[TwoFlavor.NU_E] == TwoFlavor.NU_E
+        assert TwoFlavor[TwoFlavor.NU_X] == TwoFlavor.NU_X
+        with pytest.raises(TypeError):
+            TwoFlavor[ThreeFlavor.NU_E]
+            
+    @staticmethod
+    def test_values_from_different_enums():
+        assert TwoFlavor.NU_E==ThreeFlavor.NU_E
+        assert TwoFlavor.NU_E_BAR==ThreeFlavor.NU_E_BAR
+    
+    @staticmethod
+    def test_makeFlavorScheme():
+        TestFlavor = flavor.makeFlavorScheme('TestFlavor',['A','B','C'])
+        assert len(TestFlavor)==6
+        assert [f.name for f in TestFlavor]==['NU_A','NU_A_BAR','NU_B','NU_B_BAR','NU_C','NU_C_BAR']
+
+    @staticmethod
+    def test_flavor_properties():
+        f = ThreeFlavor.NU_E
+        assert f.is_neutrino
+        assert f.is_electron
+        assert not f.is_muon
+        assert not f.is_tauon
+        assert f.lepton=='E'
+        
+        f = ThreeFlavor.NU_MU
+        assert f.is_neutrino
+        assert not f.is_electron
+        assert f.is_muon
+        assert not f.is_tauon
+        assert f.lepton=='MU'
+
+        f = ThreeFlavor.NU_E_BAR
+        assert not f.is_neutrino
+        assert f.is_electron
+        assert not f.is_muon
+        assert not f.is_tauon
+        assert f.lepton=='E'
+
+        f = ThreeFlavor.NU_MU_BAR
+        assert not f.is_neutrino
+        assert not f.is_electron
+        assert f.is_muon
+        assert not f.is_tauon
+        assert f.lepton=='MU'
+
+        f = ThreeFlavor.NU_TAU
+        assert f.is_neutrino
+        assert not f.is_electron
+        assert not f.is_muon
+        assert f.is_tauon
+        assert f.lepton=='TAU'
+
+        f = ThreeFlavor.NU_TAU_BAR
+        assert not f.is_neutrino
+        assert not f.is_electron
+        assert not f.is_muon
+        assert f.is_tauon
+        assert f.lepton=='TAU'
+
+class TestFlavorMatrix:
+    @staticmethod
+    def test_init_square_matrix():
+        m = flavor.FlavorMatrix(array=np.ones(shape=(4,4)), flavors=TwoFlavor)
+        assert m.shape == (4,4)
+        assert m.flavors_from == TwoFlavor
+        assert m.flavors_to == TwoFlavor
+        
+    @staticmethod
+    def test_init_square_matrix_with_wrong_shape_raises_ValueError():
+        with pytest.raises(ValueError):
+            m = flavor.FlavorMatrix(array=np.ones(shape=(4,5)), flavors=TwoFlavor)
+        with pytest.raises(ValueError):
+            m = flavor.FlavorMatrix(array=np.ones(shape=(5,5)), flavors=TwoFlavor)
+        with pytest.raises(ValueError):
+            m = flavor.FlavorMatrix(array=np.ones(shape=(5,4)), flavors=TwoFlavor)

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -102,14 +102,16 @@ class TestFlavorMatrix:
     @staticmethod
     def test_conversion_matrices_for_same_flavor_are_unity():
         for flavor in [TwoFlavor,ThreeFlavor,FourFlavor]:
-            matrix = FlavorMatrix.conversion_matrix(flavor,flavor)
-            print(matrix)
+            matrix = flavor>>flavor
+            assert isinstance(matrix, FlavorMatrix)
             assert np.allclose(matrix.array, np.eye(len(flavor)))
 
     @staticmethod
     @pytest.mark.parametrize('flavor_in',flavor_schemes)
     @pytest.mark.parametrize('flavor_out',flavor_schemes)
     def test_conversion_matrices(flavor_in, flavor_out):
-        M = FlavorMatrix.conversion_matrix(flavor_out,flavor_in)
+        M = flavor_in>>flavor_out
+        assert M==flavor_out<<flavor_in
+        assert isinstance(M, FlavorMatrix)
         assert M.flavor_in == flavor_in
         assert M.flavor_out == flavor_out

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -89,6 +89,28 @@ class TestFlavorMatrix:
         assert m.shape == (4,4)
         assert m.flavor_in == TwoFlavor
         assert m.flavor_out == TwoFlavor
+
+    @staticmethod
+    def test_getitem():
+        m = FlavorMatrix.eye(TwoFlavor,TwoFlavor)
+        assert m[TwoFlavor.NU_E, TwoFlavor.NU_E]==1
+        assert m['NU_E','NU_E']==1
+        assert m['NU_E','NU_X']==0
+        assert np.allclose(m['NU_E'], [1,0,0,0])
+        assert np.allclose(m['NU_E'], m['NU_E',:])
+        assert np.allclose(m[:,:], m.array)
+
+    @staticmethod
+    def test_setitem():
+        m = FlavorMatrix.eye(TwoFlavor,TwoFlavor)
+        m['NU_E']=[2,3,4,5]
+        assert m['NU_E','NU_E']==2
+        assert m['NU_E','NU_X']==4
+        #check that nothing changed in other parts
+        assert m['NU_X','NU_E']==0
+        assert m['NU_X','NU_X']==1
+        m['NU_E','NU_E_BAR']=123
+        assert m['NU_E','NU_E_BAR']==123
         
     @staticmethod
     def test_init_square_matrix_with_wrong_shape_raises_ValueError():


### PR DESCRIPTION
This is a suggestion for #309 

- [x] Implement `FlavorScheme` base class and building `TwoFlavor, ThreeFlavor, FourFlavor` enums as it's children
- [x]  Implement `FlavorMatrix` class, which contains:
  * `flavors1`, `flavors2`: children of `FlavorScheme`flavor schemes - it means that matrix transforms from `flavor1` space to `flavors2`
  * `array: np.ndarray` the matrix itself
- [x] Implement conversion matrices between various `FlavorShemes`, and make them easily accessible
- [x] Keep the `FlavorScheme` inside the `flux.Container` class (before it stored an array of `flavor` values, but we need to keep the full scheme, to be able to operate on it)
- [x] Implement matrix multiplication `FlavorMatrix @ FlavorMatrix -> FlavorMatrix`
- [x] Implement matrix multiplication `FlavorMatrix @ flux.Container -> flux.Container`

See the description below