### PR TITLE
Fix bulk downloader

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,11 +27,8 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_JM }}
       run: |
-        python -c 'import python.snewpy; python.snewpy._get_model_urls()'
-        cat python/snewpy/_model_urls.py
         pip install .
-        python -c 'import snewpy; snewpy.get_models(models="Bollig_2016")'
-        rm -r SNEWPY_models/
+        python -c 'import snewpy; print(snewpy.__version__)'
         python setup.py sdist bdist_wheel
         twine upload dist/*
 

--- a/python/snewpy/__init__.py
+++ b/python/snewpy/__init__.py
@@ -86,29 +86,3 @@ def get_models(models=None, download_dir=None):
         print("Please check your internet connection and try again later. If this persists, please report it at https://github.com/SNEWS2/snewpy/issues")
         exit(1)
     pool.shutdown(wait=False)
-
-
-def _get_model_urls():
-    """List URLs of model files for the current release.
-
-    When building a snewpy release, generate a dictionary of available models
-    and the URLs at which the respective files are located. Users can then use
-    get_models() to interactively select which model(s) to download.
-    """
-
-    repo_dir = os.path.normpath(os.path.dirname(os.path.abspath(__file__)) + '/../../')
-    url_base = 'https://github.com/SNEWS2/snewpy/raw/v' + __version__
-
-    with open(os.path.dirname(os.path.abspath(__file__)) + '/_model_urls.py', 'w') as f:
-        f.write('model_urls = {\n')
-        for model in sorted(os.listdir(repo_dir + '/models')):
-            urls = []
-            for root, dirs, files in os.walk(repo_dir + '/models/' + model):
-                for file in files:
-                    urls.append(f'{url_base}{root[len(repo_dir):]}/{file}')
-
-            f.write(f'    "{model}": [\n')
-            for url in sorted(urls):
-                f.write(f'        "{url}",\n')
-            f.write('    ],\n')
-        f.write('}\n')

--- a/python/snewpy/_model_urls.py
+++ b/python/snewpy/_model_urls.py
@@ -1,6 +1,0 @@
-"""Dictionary of models and URLs where model files are available to download.
-When preparing a snewpy release, this dictionary should be automatically
-generated using _get_model_urls() in __init__.py. Do NOT edit this manually.
-"""
-
-model_urls = {}

--- a/python/snewpy/models/__init__.py
+++ b/python/snewpy/models/__init__.py
@@ -1,7 +1,5 @@
-import logging
 from warnings import warn
 
-from snewpy import get_models, model_path
 from . import ccsn, presn
 
 
@@ -12,18 +10,13 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
-def _init_model(model_name, download=True, download_dir=model_path, **user_param):
+def _init_model(model_name, **user_param):
     """Attempts to retrieve instantiated SNEWPY model using model class name and model parameters.
-    If a model name is valid, but is not found and `download`=True, this function will attempt to download the model
 
     Parameters
     ----------
     model_name : str
         Name of SNEWPY model to import, must exactly match the name of the corresponding model class
-    download : bool
-        Switch for attempting to download model data if the first load attempt failed due to a missing file.
-    download_dir : str
-        Local directory to download model files to.
     user_param : varies
         User-requested model parameters used to initialize the model, if one is found.
         Error checking is performed during model initialization
@@ -57,13 +50,4 @@ def _init_model(model_name, download=True, download_dir=model_path, **user_param
     else:
         raise ValueError(f"Unable to find model with name '{model_name}' in snewpy.models.ccsn or snewpy.models.presn")
 
-    try:
-        return getattr(module, model_name)(**user_param)
-    except FileNotFoundError as e:
-        logger = logging.getLogger()
-        logger.warning(f"Unable to find model {model_name} in {download_dir}")
-        if not download:
-            raise e
-        logger.warning(f"Attempting to download model...")
-        get_models(model_name, download_dir)
-        return getattr(module, model_name)(**user_param)
+    return getattr(module, model_name)(**user_param)

--- a/python/snewpy/test/test_02_models.py
+++ b/python/snewpy/test/test_02_models.py
@@ -8,19 +8,12 @@ from snewpy.models.ccsn_loaders import Nakazato_2013, Tamborra_2014, OConnor_201
                                   Sukhbold_2015, Bollig_2016, Walk_2018, \
                                   Walk_2019, Fornax_2019, Warren_2020, \
                                   Kuroda_2020, Fornax_2021, Zha_2021
-from snewpy._model_urls import model_urls
 from astropy import units as u
 from snewpy import model_path
 import os
 
 
 class TestModels(unittest.TestCase):
-
-    def test_model_urls(self):
-        """Test that snewpy._model_urls.model_urls is empty. This should be populated if snewpy is downloaded from PyPI.
-        This serves as a guard against accidentally committing/merging a populated model_urls to main.
-        """
-        self.assertFalse(model_urls)
 
     def test_Nakazato_2013(self):
         """


### PR DESCRIPTION
One more problem discovered while preparing the v1.5 release: The bulk downloader (`snewpy.get_models()`) broke when moving model files to separate repositories.

This PR fixes it and ensures it uses the same download code as model initialisers (iterating over all parameter_combinations, rather than using its own dictionary of hardcoded file names); to avoid future breakage.

As a side effect, the bulk downloader will now download to the same `snewpy.model_path`, rather then the current directory. This is good for consistency and may avoid duplicate downloads.
The parameter `download_dir` was never officially documented; I’m still marking it as deprecated though, to be safe.