### PR TITLE
Fix docs build and add it to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,13 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install SNEWPY
         run: |
-          pip install ".[dev]"
+          pip install ".[dev,docs]"
       
-      # Run the unit tests
-      - name: Test with pytest
+      - name: Run unit tests with pytest
         run: |
           pytest -m 'not snowglobes'
+
+      - name: Build HTML docs
+        run: |
+          cd doc/
+          make html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,7 +15,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = --fail-on-warning --keep-going -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,7 +15,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = --fail-on-warning --keep-going -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -W --keep-going -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 

--- a/python/snewpy/models/presn.py
+++ b/python/snewpy/models/presn.py
@@ -11,10 +11,10 @@ from astropy import units as u
     progenitor_mass = [15, 25]<<u.Msun
 )
 class Odrzywolek_2010(loaders.Odrzywolek_2010):
-    """Presupernova model based on 
+    """Presupernova model based on
     `A.Odrzywolek, Alexander Heger, Acta Phys.Polon.B 41 (2010) <https://inspirehep.net/literature/870759>`_
     
-    Dataset available at `website <http://th.if.uj.edu.pl/~odrzywolek/psns/index.html>`_ 
+    Dataset available on `Odrzywolek’s website <http://th.if.uj.edu.pl/~odrzywolek/psns/index.html>`_
     """
     def __init__(self, progenitor_mass:u.Quantity):
         filename=f"s{progenitor_mass.to_value('Msun'):.0f}_nuebar_data.txt"
@@ -24,10 +24,10 @@ class Odrzywolek_2010(loaders.Odrzywolek_2010):
     progenitor_mass = [15, 30]<<u.Msun
 )
 class Patton_2017(loaders.Patton_2017):
-    """Presupernova model based on 
-    `Kelly M. Patton et al 2017 ApJ 851 6 <https://iopscience.iop.org/article/10.3847/1538-4357/aa95c4>`_
+    """Presupernova model based on
+    `Kelly M. Patton et al. 2017 ApJ 851 6 <https://iopscience.iop.org/article/10.3847/1538-4357/aa95c4>`_
     
-    Dataset available at `Zenodo <http://doi.org/10.5281/zenodo.2626645>`_
+    Dataset available on Zenodo (`DOI:10.5281/zenodo.2626645 <http://doi.org/10.5281/zenodo.2626645>`_)
     """
     def __init__(self, progenitor_mass:u.Quantity):
         filename=f"totalLuminosity_{progenitor_mass.to_value('Msun'):.0f}SolarMass.dat"
@@ -37,10 +37,10 @@ class Patton_2017(loaders.Patton_2017):
     progenitor_mass = [12, 15]<<u.Msun
 )
 class Kato_2017(loaders.Kato_2017):
-    """Presupernova model based on 
-    `Chinami Kato et al 2017 ApJ 848 48 <https://iopscience.iop.org/article/10.3847/1538-4357/aa8b72>`_
+    """Presupernova model based on
+    `Chinami Kato et al. 2017 ApJ 848 48 <https://iopscience.iop.org/article/10.3847/1538-4357/aa8b72>`_
     
-    Dataset available at `Zenodo <https://zenodo.org/records/3768052>`_
+    Dataset available on `Zenodo <https://zenodo.org/records/3768052>`__
     """
     def __init__(self, progenitor_mass:u.Quantity):
         path=f"pre_collapse/m{progenitor_mass.to_value('Msun'):.0f}"


### PR DESCRIPTION
Fixes #327.

In addition to fixing the warning itself, this includes measures to more quickly discover similar issues in the future:
This PR now treats warnings as errors in our docs Makefile, consistent with ReadTheDocs’ configuration. It also builds docs as part of our CI workflows, so we notice future issues on every PR and can fix them before merging broken docs into `main`.