### PR TITLE
Proof of concept: Initialise all models as ThreeFlavor

### DIFF
--- a/python/snewpy/models/base.py
+++ b/python/snewpy/models/base.py
@@ -235,11 +235,14 @@ class PinchedModel(SupernovaModel):
         metadata: dict
             Model parameters dict
         """
-        if not 'L_NU_X_BAR' in simtab.colnames:
-            # table only contains NU_E, NU_E_BAR, and NU_X, so double up
-            # the use of NU_X for NU_X_BAR.
+        if not 'L_NU_MU' in simtab.colnames:
+            # table only contains NU_E, NU_E_BAR, and NU_X, so re-use NU_X for MU/TAU (anti)neutrinos.
             for val in ['L','E','ALPHA']:
-                simtab[f'{val}_NU_X_BAR'] = simtab[f'{val}_NU_X']
+                simtab[f'{val}_NU_MU'] = simtab[f'{val}_NU_X']
+                simtab[f'{val}_NU_MU_BAR'] = simtab[f'{val}_NU_X']
+                simtab[f'{val}_NU_TAU'] = simtab[f'{val}_NU_X']
+                simtab[f'{val}_NU_TAU_BAR'] = simtab[f'{val}_NU_X']
+                del simtab[f'{val}_NU_X']
         # Get grid of model times.
         time = simtab['TIME'] << u.s
         # Set up dictionary of luminosity, mean energy and shape parameter

--- a/python/snewpy/models/presn_loaders.py
+++ b/python/snewpy/models/presn_loaders.py
@@ -84,9 +84,12 @@ class Patton_2017(SupernovaModel):
             self.request_file(filename),
             comment="#",
             sep='\s+',
-            names=["time","Enu",Flavor.NU_E,Flavor.NU_E_BAR,Flavor.NU_X,Flavor.NU_X_BAR],
+            names=["time","Enu",Flavor.NU_E,Flavor.NU_E_BAR,Flavor.NU_MU,Flavor.NU_MU_BAR],
             usecols=range(6),
         )
+
+        df[Flavor.NU_TAU] = df[Flavor.NU_MU]
+        df[Flavor.NU_TAU_BAR] = df[Flavor.NU_MU_BAR]
 
         df = df.set_index(["time", "Enu"])
         times = df.index.levels[0].to_numpy()
@@ -115,10 +118,12 @@ class Kato_2017(SupernovaModel):
         times, step = np.loadtxt(self.request_file(f"{path}/total_nue/lightcurve_nue_all.dat"), usecols=[0, 3]).T
 
         file_base = {Flavor.NU_E: 'total_nue/spe_all',
-                 Flavor.NU_E_BAR:'total_nueb/spe_all',
-                 Flavor.NU_X:    'total_nux/spe_sum_mu_nu',
-                 Flavor.NU_X_BAR:'total_nux/spe_sum_mu'
-                 }
+                     Flavor.NU_E_BAR: 'total_nueb/spe_all',
+                     Flavor.NU_MU: 'total_nux/spe_sum_mu_nu',
+                     Flavor.NU_MU_BAR: 'total_nux/spe_sum_mu',
+                     Flavor.NU_TAU: 'total_nux/spe_sum_mu_nu',
+                     Flavor.NU_TAU_BAR: 'total_nux/spe_sum_mu'
+                     }
         for flv,file_base in file_base.items():
             d2NdEdT = []
             for s in step:

--- a/python/snewpy/neutrino.py
+++ b/python/snewpy/neutrino.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Optional
 import numpy as np
 from collections.abc import Mapping
-from .flavor import TwoFlavor as Flavor
+from .flavor import ThreeFlavor as Flavor
 
 class MassHierarchy(IntEnum):
     """Neutrino mass ordering: ``NORMAL`` or ``INVERTED``."""

--- a/python/snewpy/test/test_03_neutrino.py
+++ b/python/snewpy/test/test_03_neutrino.py
@@ -14,25 +14,25 @@ class TestNeutrino(unittest.TestCase):
         """
         Neutrino flavor types
         """
-        nue  = Flavor.NU_E
+        nue = Flavor.NU_E
         self.assertTrue(nue.is_electron)
         self.assertTrue(nue.is_neutrino)
         self.assertFalse(nue.is_antineutrino)
 
-        nux  = Flavor.NU_X
-        self.assertFalse(nux.is_electron)
-        self.assertTrue(nux.is_neutrino)
-        self.assertFalse(nux.is_antineutrino)
+        numu = Flavor.NU_MU
+        self.assertFalse(numu.is_electron)
+        self.assertTrue(numu.is_neutrino)
+        self.assertFalse(numu.is_antineutrino)
 
         nueb = Flavor.NU_E_BAR
         self.assertTrue(nueb.is_electron)
         self.assertFalse(nueb.is_neutrino)
         self.assertTrue(nueb.is_antineutrino)
 
-        nuxb = Flavor.NU_X_BAR
-        self.assertFalse(nuxb.is_electron)
-        self.assertFalse(nuxb.is_neutrino)
-        self.assertTrue(nuxb.is_antineutrino)
+        numub = Flavor.NU_MU_BAR
+        self.assertFalse(numub.is_electron)
+        self.assertFalse(numub.is_neutrino)
+        self.assertTrue(numub.is_antineutrino)
 
 
     def test_mixing_nmo(self):

--- a/python/snewpy/test/test_05_snowglobes.py
+++ b/python/snewpy/test/test_05_snowglobes.py
@@ -32,6 +32,7 @@ def rates_calculation(fluence_file):
         result[det] = table['weighted']['smeared'].values.sum()
     return result
 
+@pytest.mark.xfail(reason="Rate calculation uses `get_transformed_flux`, which is currently hard coded to a TwoFlavor scheme.", raises=AttributeError)
 @pytest.mark.parametrize('model_parameters',param_values)
 def test_total_rate_equals_table_value(model_parameters):
     fluence_file = fluence_calculation(*model_parameters)

--- a/python/snewpy/test/test_presn_rates.py
+++ b/python/snewpy/test/test_presn_rates.py
@@ -14,6 +14,7 @@ distance = 200*u.pc
 T = np.geomspace(-1*u.hour, -1*u.min,1000)
 E = np.linspace(0,20,100)*u.MeV
 
+@pytest.mark.xfail(reason="`model.get_flux` uses `get_transformed_flux`, which is currently hard coded to a TwoFlavor scheme.", raises=AttributeError)
 @pytest.mark.parametrize('model_class',[presn.Odrzywolek_2010, presn.Kato_2017, presn.Patton_2017])
 @pytest.mark.parametrize('transformation',[AdiabaticMSW(mh=mh) for mh in MassHierarchy])
 @pytest.mark.parametrize('detector', ["wc100kt30prct"])

--- a/python/snewpy/test/test_rate_calculation.py
+++ b/python/snewpy/test/test_rate_calculation.py
@@ -42,6 +42,7 @@ def fluence(snmodel):
     flux = snmodel.get_flux(t=times, E=energies, distance=10<<u.kpc, flavor_xform=ft.AdiabaticMSW())
     return flux.integrate('time')
 
+@pytest.mark.xfail(reason="Fluence calculation uses `get_transformed_flux`, which is currently hard coded to a TwoFlavor scheme.", raises=AttributeError)
 @pytest.mark.parametrize('detector, expected_total',crosscheck_table_unsmeared)
 def test_rate_unsmeared(rc, fluence, detector, expected_total):    
     #calculate the event rates
@@ -52,6 +53,7 @@ def test_rate_unsmeared(rc, fluence, detector, expected_total):
     #check the final value
     assert N_total == pytest.approx(expected_total, 0.01)
     
+@pytest.mark.xfail(reason="Fluence calculation uses `get_transformed_flux`, which is currently hard coded to a TwoFlavor scheme.", raises=AttributeError)
 @pytest.mark.parametrize('detector, expected_total',crosscheck_table)
 def test_rate_smeared(rc, fluence, detector, expected_total):
     #calculate the event rates


### PR DESCRIPTION
For demonstration purposes, following the discussion in #309.

The changes are fairly small and well contained.

For most models (presn and ccsn), we already had code to map the columns in the input files (usually NU_E, NU_E_BAR and NU_X, i.e. a “OnePointFiveFlavor scheme”) to the TwoFlavor scheme; I’ve simply updated these existing mappings. With this, all tests run by `pytest -m 'not snowglobes'` succeed.

Of course, the `FlavorTransformation`s are currently hardcoded to the TwoFlavor scheme; so any code that uses these transformations (mainly via `SupernovaModel.get_transformed_flux`) cannot currently switch to ThreeFlavor scheme. This is already changing in #308; so for the purposes of this proof of concept, I’ve marked those as [xfails](https://docs.pytest.org/en/6.2.x/reference.html#pytest-mark-xfail-ref).