### PR TITLE
Drop Python 3.8 and 3.9 Support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       # Add a list of python versions we want to use for testing.
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       # Add a list of python versions we want to use for testing.
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       # Add a list of python versions we want to use for testing.
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       # Add a list of python versions we want to use for testing.
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/python/snewpy/_model_downloader.py
+++ b/python/snewpy/_model_downloader.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from importlib.resources import open_text
 from pathlib import Path
 from tqdm.auto import tqdm
-from typing import Optional
 
 from snewpy import model_path
 from snewpy import __version__ as snewpy_version
@@ -79,7 +78,7 @@ class FileHandle:
 
     path: Path
     remote: str = None
-    md5: Optional[str] = None
+    md5: str | None = None
 
     def check(self) -> None:
         """Check if the given file exists locally and has a correct md5 sum.

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -51,7 +51,8 @@ Reference
 .. autoclass:: Axes
 
 """
-#from snewpy.neutrino import Flavor
+from typing import Union
+# from snewpy.neutrino import Flavor
 from snewpy.flavor import FlavorScheme, FlavorMatrix
 from astropy import units as u
 
@@ -72,7 +73,7 @@ class Axes(IntEnum):
     energy=2, #Energy dimension
     
     @classmethod
-    def get(cls, value: 'Axes' | int | str)->'Axes':
+    def get(cls, value: Union['Axes', int, str])->'Axes':
         "convert string, int or Axes value to Axes"
         if isinstance(value,str):
             return cls[value]

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -51,7 +51,7 @@ Reference
 .. autoclass:: Axes
 
 """
-from typing import Union, Optional, Set, List
+from typing import Union, Optional
 #from snewpy.neutrino import Flavor
 from snewpy.flavor import FlavorScheme, FlavorMatrix
 from astropy import units as u
@@ -87,11 +87,11 @@ class _ContainerBase:
     unit = None
     def __init__(self, 
                  data: u.Quantity,
-                 flavor: List[FlavorScheme],
+                 flavor: list[FlavorScheme],
                  time: u.Quantity[u.s], 
                  energy: u.Quantity[u.MeV],
                  *,
-                 integrable_axes: Optional[Set[Axes]] = None,
+                 integrable_axes: Optional[set[Axes]] = None,
                  flavor_scheme:Optional[FlavorScheme] = None
     ):
         """A container class storing the physical quantity (flux, fluence, rate...), which depends on flavor, time and energy.

--- a/python/snewpy/flux.py
+++ b/python/snewpy/flux.py
@@ -51,7 +51,6 @@ Reference
 .. autoclass:: Axes
 
 """
-from typing import Union, Optional
 #from snewpy.neutrino import Flavor
 from snewpy.flavor import FlavorScheme, FlavorMatrix
 from astropy import units as u
@@ -73,8 +72,8 @@ class Axes(IntEnum):
     energy=2, #Energy dimension
     
     @classmethod
-    def get(cls, value:Union['Axes',int,str])->'Axes':
-        "convert string,int or Axes value to Axes"
+    def get(cls, value: 'Axes' | int | str)->'Axes':
+        "convert string, int or Axes value to Axes"
         if isinstance(value,str):
             return cls[value]
         else:
@@ -85,14 +84,14 @@ class _ContainerBase:
     :noindex:
     """
     unit = None
-    def __init__(self, 
+    def __init__(self,
                  data: u.Quantity,
                  flavor: list[FlavorScheme],
-                 time: u.Quantity[u.s], 
+                 time: u.Quantity[u.s],
                  energy: u.Quantity[u.MeV],
                  *,
-                 integrable_axes: Optional[set[Axes]] = None,
-                 flavor_scheme:Optional[FlavorScheme] = None
+                 integrable_axes: set[Axes] | None = None,
+                 flavor_scheme: FlavorScheme | None = None
     ):
         """A container class storing the physical quantity (flux, fluence, rate...), which depends on flavor, time and energy.
 
@@ -204,7 +203,7 @@ class _ContainerBase:
         ]
         return f"{self.__class__.__name__} {self.array.shape} [{self.array.unit}]: <{' x '.join(s)}>"
     
-    def sum(self, axis: Union[Axes,str])->'Container':
+    def sum(self, axis: Axes | str)->'Container':
         """Sum along given axis, producing a Container with the summary quantity.
         
         Parameters
@@ -249,7 +248,7 @@ class _ContainerBase:
         axes[axis] = axes[axis].take([0,-1])
         return Container(array,*axes, integrable_axes = self._integrable_axes.difference({axis}))
 
-    def integrate(self, axis:Union[Axes,str], limits:np.ndarray=None)->'Container':
+    def integrate(self, axis: Axes | str, limits:np.ndarray=None)->'Container':
         """Integrate along given axis, producing a Container with the integral quantity.
         
         Parameters
@@ -317,7 +316,7 @@ class _ContainerBase:
         #choose the proper class
         return Container(array, *axes, integrable_axes=self._integrable_axes.difference({axis}))
 
-    def integrate_or_sum(self, axis:Union[Axes,str])->'Container':
+    def integrate_or_sum(self, axis: Axes | str)->'Container':
         if self.can_integrate(axis):
             return self.integrate(axis)
         else:

--- a/python/snewpy/neutrino.py
+++ b/python/snewpy/neutrino.py
@@ -4,7 +4,6 @@
 from enum import IntEnum
 from astropy import units as u
 from dataclasses import dataclass
-from typing import Optional
 import numpy as np
 from collections.abc import Mapping
 from .flavor import ThreeFlavor as Flavor
@@ -41,10 +40,10 @@ class MixingParameters3Flavor(Mapping):
     deltaCP: u.Quantity[u.deg]
     #square mass difference
     dm21_2: u.Quantity[u.eV**2]
-    dm32_2: Optional[u.Quantity] = None
-    dm31_2: Optional[u.Quantity] = None
+    dm32_2: u.Quantity | None = None
+    dm31_2: u.Quantity | None = None
     #mass ordering
-    mass_order: Optional[MassHierarchy] = None
+    mass_order: MassHierarchy | None = None
     # Note: in IH, the mass splittings are: m3..............m1..m2.
 
     def __iter__(self):
@@ -124,8 +123,8 @@ class MixingParameters4Flavor(MixingParameters3Flavor):
     theta34: u.Quantity[u.deg] = 0<<u.deg
     #sterile neutrino mass squared differences
     dm41_2: u.Quantity[u.eV**2] = 0<<u.eV**2
-    dm42_2: Optional[u.Quantity] = None
-    dm43_2: Optional[u.Quantity] = None
+    dm42_2: u.Quantity | None = None
+    dm43_2: u.Quantity | None = None
     
     def __post_init__(self):
         super().__post_init__()

--- a/python/snewpy/rate_calculator.py
+++ b/python/snewpy/rate_calculator.py
@@ -12,7 +12,6 @@ from snewpy.neutrino import Flavor
 from snewpy.flux import Container
 from astropy import units as u
 from warnings import warn
-from typing import Dict
 from typing import Callable
 import scipy.stats as st
 
@@ -245,7 +244,7 @@ class DetectionChannel:
 class Detector:
     """A detector configuration for the rate calculation. """
     
-    def __init__(self, name:str, mass: u.Quantity, channels: Dict[str,DetectionChannel]):
+    def __init__(self, name:str, mass: u.Quantity, channels: dict[str,DetectionChannel]):
         """
         Parameters
         ----------
@@ -253,7 +252,7 @@ class Detector:
             Detector name
         mass: Quantity[mass]
             Detector mass
-        channels: Dict[str,DetectionChannel]
+        channels: dict[str,DetectionChannel]
             Dictionary of detection channels in the format {name:channel}
     
         Note
@@ -267,7 +266,7 @@ class Detector:
     def __repr__(self):
         return f'Detector(name="{self.name}", mass={self.mass}, channels={list(self.channels)})'
     
-    def run(self, flux:Container, detector_effects:bool=True)->Dict[str, Container]:
+    def run(self, flux:Container, detector_effects:bool=True)->dict[str, Container]:
         """Calculate the interaction rates for all channels in the detector.
 
         Parameters
@@ -279,7 +278,7 @@ class Detector:
 
         Returns
         -------
-        Dict[str,Container]
+        dict[str,Container]
             Event rate for each detection channel in as dictionary {channel name: event rate}
         """
         result = {}
@@ -401,7 +400,7 @@ class RateCalculator(SnowglobesData):
                         mass=self.detectors[name].mass<<u.kt,
                         channels=channels
                        )
-    def run(self, flux:Container, detector:str, material:str=None, detector_effects:bool = True)->Dict[str, Container]:
+    def run(self, flux:Container, detector:str, material:str=None, detector_effects:bool = True)->dict[str, Container]:
         """Run the rate calculation for the given detector.    
         
         Parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ h5py
 requests
 pyyaml
 snowglobes_data == 1.3.2
-importlib_resources; python_version < "3.9"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.md'):
 # See https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 # setup_keywords['entry_points'] = {'console_scripts': ['to_snowglobes = snewpy.to_snowglobes:generate_time_series', ], },
 setup_keywords['provides'] = [setup_keywords['name']]
-setup_keywords['python_requires'] = '>=3.9'
+setup_keywords['python_requires'] = '>=3.10'
 setup_keywords['zip_safe'] = False
 setup_keywords['packages'] = find_packages('python')
 setup_keywords['package_dir'] = {'': 'python'}

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.md'):
 # See https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 # setup_keywords['entry_points'] = {'console_scripts': ['to_snowglobes = snewpy.to_snowglobes:generate_time_series', ], },
 setup_keywords['provides'] = [setup_keywords['name']]
-setup_keywords['python_requires'] = '>=3.8'
+setup_keywords['python_requires'] = '>=3.9'
 setup_keywords['zip_safe'] = False
 setup_keywords['packages'] = find_packages('python')
 setup_keywords['package_dir'] = {'': 'python'}


### PR DESCRIPTION
This PR drops support for Python 3.8 and cleans up some backwards compatibility code.

Python 3.8 is [scheduled to reach end-of-life this autumn](https://peps.python.org/pep-0569/#lifespan); and many major packages in the scientific Python ecosystem already started dropping 3.8 support [since April 2023](https://numpy.org/neps/nep-0029-deprecation_policy.html).

@Sheshuk: If there are any places in the SNEWPY 2.0 code where support for Python 3.9 is holding us back, we can consider dropping 3.9 support as well. (NumPy and others started doing that in April 2024.)