### PR TITLE
Sheshuk/update flavor matrix interface

### DIFF
--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -131,6 +131,10 @@ class FlavorMatrix:
     @property
     def flavor(self):
         return self.flavor_out
+    @property
+    def T(self):
+        "transposed version of the matrix: reverse the flavor dimensions"
+        return FlavorMatrix(array = self.swapaxes(0,1), flavor = self.flavor_in, from_flavor=self.flavor_out)
         
     @classmethod
     def eye(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
@@ -138,7 +142,12 @@ class FlavorMatrix:
         shape = (len(from_flavor), len(flavor))
         data = np.eye(*shape)
         return cls(data, flavor, from_flavor)
-
+    @classmethod
+    def zeros(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
+        from_flavor = from_flavor or flavor
+        shape = (len(from_flavor), len(flavor))
+        data = np.zeros(shape)
+        return cls(data, flavor, from_flavor)
     @classmethod
     def from_function(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
         """A decorator for creating the flavor matrix from the given function"""

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -258,6 +258,9 @@ def conversion_matrix(from_flavor:FlavorScheme, to_flavor:FlavorScheme):
             # convert from more flavors to TwoFlavor
             return 0.5
         return 0.
+    #check if the conversion matrix is not zero
+    if np.allclose(convert.array, 0):
+        raise RuntimeError(f"Conversion matrix {convert._repr_short()} is zero!")
     return convert
 
 def rshift(flv:FlavorScheme, obj:FlavorScheme|FlavorMatrix)->FlavorMatrix:

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -17,6 +17,11 @@ class EnumMeta(enum.EnumMeta):
             return key
         #if this is a string find it by name
         if isinstance(key, str):
+            #prepare the string
+            key=key.upper()
+            if not key.startswith('NU_'):
+                key = 'NU_'+key
+            #try to get the proper values
             try:
                 return super().__getitem__(key)
             except KeyError as e:

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -90,7 +90,7 @@ class FlavorMatrix:
                     self.flavor_out = flavor
                     self.flavor_in = from_flavor or flavor
                     expected_shape = (len(self.flavor_out), len(self.flavor_in))
-                    if(self.array.shape != expected_shape):
+                    if(self.array.shape[:2] != expected_shape):
                         raise ValueError(f"FlavorMatrix array shape {self.array.shape} mismatch expected {expected_shape}")
        
     def _convert_index(self, index):
@@ -109,7 +109,9 @@ class FlavorMatrix:
         return f'{self.__class__.__name__}:<{self.flavor_in.__name__}->{self.flavor_out.__name__}> shape={self.shape}'
         
     def __repr__(self):
-        s=self._repr_short()+'\n'+repr(self.array)
+        s=self._repr_short()
+        if(len(self.shape)==2):
+            s+='\n'+repr(self.array)
         return s
     def __eq__(self,other):
         return self.flavor_in==other.flavor_in and self.flavor_out==other.flavor_out and np.allclose(self.array,other.array)

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -1,6 +1,7 @@
 import enum
 import numpy as np
 import typing
+import snewpy.utils
 
 class EnumMeta(enum.EnumMeta):
     def __getitem__(cls, key):
@@ -122,7 +123,7 @@ class FlavorMatrix:
                 m0, m1 = self.array, other.array
                 ndims = max(m0.ndim, m1.ndim)
                 m0,m1 = [snewpy.utils.expand_dimensions_to(m, ndim=ndims) for m in [m0,m1]]
-                array = np.einsum('ij...,jk...->ik...',m,f)
+                array = np.einsum('ij...,jk...->ik...',m0,m1)
                 np.tensordot(self.array, other.array, axes=[1,0])
                 return FlavorMatrix(array, self.flavor_out, from_flavor = other.flavor_in)
             except Exception as e:

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -19,6 +19,12 @@ class EnumMeta(enum.EnumMeta):
         if isinstance(key, str):
             #prepare the string
             key=key.upper()
+            #check cases for neutrinos and antineutrinos
+            if key=='NU':
+                return tuple([f for f in cls.__members__.values() if f.is_neutrino])
+            elif key=='NU_BAR':
+                return tuple([f for f in cls.__members__.values() if not f.is_neutrino])
+            #add the prefix if needed
             if not key.startswith('NU_'):
                 key = 'NU_'+key
             #try to get the proper values
@@ -104,6 +110,12 @@ class FlavorMatrix:
             index = [index]
         #convert flavor dimensions
         new_idx = [flavors[idx] for idx,flavors in zip(index, [self.flavor_out, self.flavor_in])]
+        #try to convert first index to list of bracketed index
+        try:
+            new_idx[0] = [[f] for f in new_idx[0]]
+        except:
+            #it was not iterable
+            pass 
         #add remaining dimensions
         new_idx+=list(index[2:])
         return tuple(new_idx)

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -3,7 +3,7 @@ import numpy as np
 import typing
 import snewpy.utils
 
-class EnumMeta(enum.EnumMeta):
+class FlavorEnumMeta(enum.EnumMeta):
     def __getitem__(cls, key):
         #if this is an iterable: apply to each value, and construct a tuple
         if isinstance(key, slice):
@@ -40,7 +40,7 @@ class EnumMeta(enum.EnumMeta):
         #if this is anything else - treat it as a slice
         return np.array(list(cls.__members__.values()),dtype=object)[key]
 
-class FlavorScheme(enum.IntEnum, metaclass=EnumMeta):
+class FlavorScheme(enum.IntEnum, metaclass=FlavorEnumMeta):
     def to_tex(self):
         """LaTeX-compatible string representations of flavor."""
         base = r'\nu'
@@ -272,7 +272,7 @@ def conversion_matrix(from_flavor:FlavorScheme, to_flavor:FlavorScheme):
     return convert
 
 def rshift(flv:FlavorScheme, obj:FlavorScheme|FlavorMatrix)->FlavorMatrix:
-    if isinstance(obj, EnumMeta):
+    if isinstance(obj, FlavorEnumMeta):
         return conversion_matrix(from_flavor=flv,to_flavor=obj)
     elif hasattr(obj, '__lshift__'):
         return obj<<flv
@@ -280,7 +280,7 @@ def rshift(flv:FlavorScheme, obj:FlavorScheme|FlavorMatrix)->FlavorMatrix:
         raise TypeError(f'Cannot apply flavor conversion to object of type {type(obj)}')
 
 def lshift(flv:FlavorScheme, obj:FlavorScheme|FlavorMatrix)->FlavorMatrix:
-    if isinstance(obj, EnumMeta):
+    if isinstance(obj, FlavorEnumMeta):
         return conversion_matrix(from_flavor=obj,to_flavor=flv)
     elif hasattr(obj, '__rshift__'):
         return obj>>flv
@@ -289,5 +289,5 @@ def lshift(flv:FlavorScheme, obj:FlavorScheme|FlavorMatrix)->FlavorMatrix:
         
         
 FlavorScheme.conversion_matrix = classmethod(conversion_matrix)
-EnumMeta.__rshift__ = rshift
-EnumMeta.__lshift__ = lshift
+FlavorEnumMeta.__rshift__ = rshift
+FlavorEnumMeta.__lshift__ = lshift

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -219,15 +219,12 @@ class FlavorMatrix:
                             flavor = self.flavor_out, from_flavor=self.flavor_in)
 
     @classmethod
-    def eye(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
-        from_flavor = from_flavor or flavor
-        shape = (len(from_flavor), len(flavor))
-        data = np.eye(*shape)
-        return cls(data, flavor, from_flavor)
+    def eye(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None, extra_dims=[]):
+        return cls.from_function(flavor,from_flavor)(lambda f1,f2: f1==f2*np.ones(shape=extra_dims))
     @classmethod
-    def zeros(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
+    def zeros(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None, extra_dims=[]):
         from_flavor = from_flavor or flavor
-        shape = (len(from_flavor), len(flavor))
+        shape = (len(from_flavor), len(flavor), *extra_dims)
         data = np.zeros(shape)
         return cls(data, flavor, from_flavor)
     @classmethod

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -119,8 +119,12 @@ class FlavorMatrix:
     def __matmul__(self, other):
         if isinstance(other, FlavorMatrix):
             try:
-                data = np.tensordot(self.array, other.array, axes=[1,0])
-                return FlavorMatrix(data, self.flavor_out, from_flavor = other.flavor_in)
+                m0, m1 = self.array, other.array
+                ndims = max(m0.ndim, m1.ndim)
+                m0,m1 = [snewpy.utils.expand_dimensions_to(m, ndim=ndims) for m in [m0,m1]]
+                array = np.einsum('ij...,jk...->ik...',m,f)
+                np.tensordot(self.array, other.array, axes=[1,0])
+                return FlavorMatrix(array, self.flavor_out, from_flavor = other.flavor_in)
             except Exception as e:
                 raise ValueError(f"Cannot multiply {self._repr_short()} by {other._repr_short()}") from e
         elif hasattr(other, '__rmatmul__'):

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -133,7 +133,24 @@ class FlavorMatrix:
     
     def __eq__(self,other):
         return self.flavor_in==other.flavor_in and self.flavor_out==other.flavor_out and np.allclose(self.array,other.array)
-                
+    @property
+    def real(self):
+        return FlavorMatrix(self.array.real, self.flavor_out, from_flavor = self.flavor_in)
+    @property
+    def imag(self):
+        return FlavorMatrix(self.array.imag, self.flavor_out, from_flavor = self.flavor_in)
+    
+    def abs(self):
+        return FlavorMatrix(np.abs(self.array), self.flavor_out, from_flavor = self.flavor_in)
+    def abs2(self):
+        return FlavorMatrix(np.abs(self.array**2), self.flavor_out, from_flavor = self.flavor_in)
+        
+    def __mul__(self, other):
+        if isinstance(other, FlavorMatrix):
+            if not ((other.flavor_in==self.flavor_in)and(other.flavor_out==self.flavor_out)):
+                raise TypeError(f"Cannot multiply matrices with different flavor schemes: {self._repr_short()} and {other._repr_short()}")
+            other = other.array
+        return FlavorMatrix(self.array*other, self.flavor_out, from_flavor = self.flavor_in)
     def __matmul__(self, other):
         if isinstance(other, FlavorMatrix):
             assert self.flavor_in==other.flavor_out, f"Incompatible spaces {self.flavor_in}!={other.flavor_out}"
@@ -174,7 +191,7 @@ class FlavorMatrix:
         "apply complex conjugate"
         return FlavorMatrix(array = self.array.conjugate(), 
                             flavor = self.flavor_out, from_flavor=self.flavor_in)
-        
+
     @classmethod
     def eye(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
         from_flavor = from_flavor or flavor

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -4,6 +4,11 @@ import typing
 import snewpy.utils
 
 class FlavorEnumMeta(enum.EnumMeta):
+    """Meta class for setting flavor enums.
+
+    Needed for calling __getitem__ on subclasses of Enum. See the discussion in
+    https://github.com/SNEWS2/snewpy/pull/324#discussion_r1598833198
+    """
     def __getitem__(cls, key):
         #if this is an iterable: apply to each value, and construct a tuple
         if isinstance(key, slice):
@@ -41,6 +46,9 @@ class FlavorEnumMeta(enum.EnumMeta):
         return np.array(list(cls.__members__.values()),dtype=object)[key]
 
 class FlavorScheme(enum.IntEnum, metaclass=FlavorEnumMeta):
+    """Configurable enumeration for different flavor schems (2, 3, 4, ... flavors).
+    """
+
     def to_tex(self):
         """LaTeX-compatible string representations of flavor."""
         base = r'\nu'
@@ -88,11 +96,14 @@ class FlavorScheme(enum.IntEnum, metaclass=FlavorEnumMeta):
     def take(cls, index):
         return cls[index]
 
+#- Define 2, 3, and 4-flavor schemes for the module.
 TwoFlavor = FlavorScheme.from_lepton_names('TwoFlavor',['E','X'])
 ThreeFlavor = FlavorScheme.from_lepton_names('ThreeFlavor',['E','MU','TAU'])
 FourFlavor = FlavorScheme.from_lepton_names('FourFlavor',['E','MU','TAU','S'])
 
 class FlavorMatrix:
+    """Encapsulate flavor transformations for any FlavorScheme, enabling conversion between an input and output FlavorScheme."""
+
     def __init__(self, 
                  array:np.ndarray,
                  flavor:FlavorScheme,
@@ -159,15 +170,18 @@ class FlavorMatrix:
     
     def __eq__(self,other):
         return self.flavor_in==other.flavor_in and self.flavor_out==other.flavor_out and np.allclose(self.array,other.array)
+
     @property
     def real(self):
         return FlavorMatrix(self.array.real, self.flavor_out, from_flavor = self.flavor_in)
+
     @property
     def imag(self):
         return FlavorMatrix(self.array.imag, self.flavor_out, from_flavor = self.flavor_in)
     
     def abs(self):
         return FlavorMatrix(np.abs(self.array), self.flavor_out, from_flavor = self.flavor_in)
+
     def abs2(self):
         return FlavorMatrix(np.abs(self.array**2), self.flavor_out, from_flavor = self.flavor_in)
         
@@ -177,6 +191,7 @@ class FlavorMatrix:
                 raise TypeError(f"Cannot multiply matrices with different flavor schemes: {self._repr_short()} and {other._repr_short()}")
             other = other.array
         return FlavorMatrix(self.array*other, self.flavor_out, from_flavor = self.flavor_in)
+
     def __matmul__(self, other):
         if isinstance(other, FlavorMatrix):
             assert self.flavor_in==other.flavor_out, f"Incompatible spaces {self.flavor_in}!={other.flavor_out}"
@@ -197,13 +212,16 @@ class FlavorMatrix:
             result = np.tensordot(self.array, array, axes=[1,0])
             return {flv:result[n] for n,flv in enumerate(self.flavor_out)}
         raise TypeError(f"Cannot multiply object of {self.__class__} by {other.__class__}")
+
     #properties
     @property
     def shape(self):
         return self.array.shape
+
     @property
     def flavor(self):
         return self.flavor_out
+
     @property
     def T(self):
         return self.transpose()
@@ -212,6 +230,7 @@ class FlavorMatrix:
         "transposed version of the matrix: reverse the flavor dimensions"
         return FlavorMatrix(array = self.array.swapaxes(0,1), 
                             flavor = self.flavor_in, from_flavor=self.flavor_out)
+
     def conjugate(self):
         "apply complex conjugate"
         return FlavorMatrix(array = self.array.conjugate(), 
@@ -220,12 +239,14 @@ class FlavorMatrix:
     @classmethod
     def eye(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None, extra_dims=[]):
         return cls.from_function(flavor,from_flavor)(lambda f1,f2: f1==f2*np.ones(shape=extra_dims))
+
     @classmethod
     def zeros(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None, extra_dims=[]):
         from_flavor = from_flavor or flavor
         shape = (len(from_flavor), len(flavor), *extra_dims)
         data = np.zeros(shape)
         return cls(data, flavor, from_flavor)
+
     @classmethod
     def from_function(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
         """A decorator for creating the flavor matrix from the given function"""
@@ -238,6 +259,7 @@ class FlavorMatrix:
                     
             return cls(np.array(data,dtype=float),  flavor, from_flavor)
         return _decorator
+
     #flavor conversion utils
     def convert_to_flavor(self, flavor_out:FlavorScheme|None=None, flavor_in:FlavorScheme|None=None):
         if flavor_out is None and flavor_in is None:
@@ -251,6 +273,7 @@ class FlavorMatrix:
     
     def __rshift__(self, flavor:FlavorScheme):
         return self.convert_to_flavor(flavor_out=flavor)
+
     def __lshift__(self, flavor:FlavorScheme):
         return self.convert_to_flavor(flavor_in=flavor)
         
@@ -287,7 +310,7 @@ def lshift(flv:FlavorScheme, obj:FlavorScheme|FlavorMatrix)->FlavorMatrix:
     else:
         raise TypeError(f'Cannot apply flavor conversion to object of type {type(obj)}')
         
-        
+# Syntactic sugar for FlavorScheme conversions
 FlavorScheme.conversion_matrix = classmethod(conversion_matrix)
 FlavorEnumMeta.__rshift__ = rshift
 FlavorEnumMeta.__lshift__ = lshift

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -114,6 +114,23 @@ class FlavorMatrix:
         if(len(self.shape)==2):
             s+='\n'+repr(self.array)
         return s
+        
+    def _repr_markdown_(self):
+        if(len(self.shape)>2):
+            return self.__repr__()
+        #make a markdown table
+        res = [f'**{self.__class__.__name__}**:<`{self.flavor_in.__name__}`->`{self.flavor_out.__name__}`> shape={self.shape}','']
+        flavors0 = [f.to_tex() for f in self.flavor_in]
+        flavors1 = [f.to_tex() for f in self.flavor_out]
+        hdr = '|'.join(['*']+flavors1)
+        res+=[hdr]
+        res+=['|'.join(['-:',]*(len(flavors1)+1))]
+        for f0 in self.flavor_in:
+            line = [f0.to_tex()]+[f'{v:.3g}' for v in self[:,f0]]
+            res+=['|'.join(line)]
+        res+=['---------']
+        return '\n'.join(res)
+    
     def __eq__(self,other):
         return self.flavor_in==other.flavor_in and self.flavor_out==other.flavor_out and np.allclose(self.array,other.array)
                 

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -119,6 +119,7 @@ class FlavorMatrix:
                 
     def __matmul__(self, other):
         if isinstance(other, FlavorMatrix):
+            assert self.flavor_in==other.flavor_out, f"Incompatible spaces {self.flavor_in}!={other.flavor_out}"
             try:
                 m0, m1 = self.array, other.array
                 ndims = max(m0.ndim, m1.ndim)
@@ -146,8 +147,16 @@ class FlavorMatrix:
         return self.flavor_out
     @property
     def T(self):
+        return self.transpose()
+    
+    def transpose(self):
         "transposed version of the matrix: reverse the flavor dimensions"
-        return FlavorMatrix(array = self.swapaxes(0,1), flavor = self.flavor_in, from_flavor=self.flavor_out)
+        return FlavorMatrix(array = self.array.swapaxes(0,1), 
+                            flavor = self.flavor_in, from_flavor=self.flavor_out)
+    def conjugate(self):
+        "apply complex conjugate"
+        return FlavorMatrix(array = self.array.conjugate(), 
+                            flavor = self.flavor_out, from_flavor=self.flavor_in)
         
     @classmethod
     def eye(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -122,7 +122,13 @@ class FlavorMatrix:
             except Exception as e:
                 raise ValueError(f"Cannot multiply {self._repr_short()} by {other._repr_short()}") from e
         elif hasattr(other, '__rmatmul__'):
-            return other.__rmatmul__(self)        
+            return other.__rmatmul__(self)
+        elif isinstance(other, dict):
+            #try to multiply to the dict[Flavor:flux]
+            #we assume that it has the same Flavor scheme!
+            array =  np.stack([other[flv] for flv in self.flavor_in])
+            result = np.tensordot(self.array, array, axes=[1,0])
+            return {flv:result[n] for n,flv in enumerate(self.flavor_out)}
         raise TypeError(f"Cannot multiply object of {self.__class__} by {other.__class__}")
     #properties
     @property

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -102,11 +102,20 @@ class FlavorMatrix:
     def _convert_index(self, index):
         if isinstance(index, str) or (not isinstance(index,typing.Iterable)):
             index = [index]
+        #convert flavor dimensions
         new_idx = [flavors[idx] for idx,flavors in zip(index, [self.flavor_out, self.flavor_in])]
+        #add remaining dimensions
+        new_idx+=list(index[2:])
         return tuple(new_idx)
         
     def __getitem__(self, index):
-        return self.array[self._convert_index(index)]
+        index = self._convert_index(index)
+        array = self.array[index]
+        #if requested all the flavors, then return a FlavorMatrix using the remaining index
+        if index[:2]==(slice(None),slice(None)):
+            return FlavorMatrix(array, self.flavor_out, self.flavor_in)
+        else:
+            return array
         
     def __setitem__(self, index, value):
         self.array[self._convert_index(index)] = value

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -185,7 +185,6 @@ class FlavorMatrix:
                 ndims = max(m0.ndim, m1.ndim)
                 m0,m1 = [snewpy.utils.expand_dimensions_to(m, ndim=ndims) for m in [m0,m1]]
                 array = np.einsum('ij...,jk...->ik...',m0,m1)
-                np.tensordot(self.array, other.array, axes=[1,0])
                 return FlavorMatrix(array, self.flavor_out, from_flavor = other.flavor_in)
             except Exception as e:
                 raise ValueError(f"Cannot multiply {self._repr_short()} by {other._repr_short()}") from e

--- a/python/snewpy/flavor.py
+++ b/python/snewpy/flavor.py
@@ -207,7 +207,8 @@ class FlavorMatrix:
     @classmethod
     def from_function(cls, flavor:FlavorScheme, from_flavor:FlavorScheme = None):
         """A decorator for creating the flavor matrix from the given function"""
-        from_flavor = from_flavor or flavor
+        if from_flavor is None: 
+            from_flavor = flavor
         def _decorator(function):
             data = [[function(f1,f2)
                      for f2 in from_flavor]

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -17,8 +17,14 @@ class TestFlavorScheme:
     def test_getitem_string():
         assert TwoFlavor['NU_E'] == TwoFlavor.NU_E
         assert TwoFlavor['NU_X'] == TwoFlavor.NU_X
+        #short notations
+        assert ThreeFlavor['E'] == ThreeFlavor['e'] == ThreeFlavor.NU_E
+        assert ThreeFlavor['MU'] == ThreeFlavor['mu'] == ThreeFlavor.NU_MU
+        assert ThreeFlavor['MU_BAR'] == ThreeFlavor['mu_bar'] == ThreeFlavor.NU_MU_BAR
         with pytest.raises(KeyError):
             TwoFlavor['NU_MU']
+        with pytest.raises(KeyError):
+            ThreeFlavor['NU_X']
             
     @staticmethod
     def test_getitem_enum():
@@ -100,6 +106,14 @@ class TestFlavorMatrix:
         assert np.allclose(m['NU_E'], m['NU_E',:])
         assert np.allclose(m[:,:], m.array)
 
+    @staticmethod
+    def test_getitem_short():
+        m = FlavorMatrix.eye(ThreeFlavor,ThreeFlavor)
+        assert m['NU_E','NU_E']==m['e','e']
+        assert m['NU_MU','NU_E']==m['mu','e']
+        assert m['NU_E_BAR','NU_E']==m['e_bar','e']
+        assert m['NU_TAU_BAR','NU_TAU']==m['tau_bar','tau']
+        
     @staticmethod
     def test_setitem():
         m = FlavorMatrix.eye(TwoFlavor,TwoFlavor)

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -141,7 +141,7 @@ class TestFlavorMatrix:
             matrix = flavor>>flavor
             assert isinstance(matrix, FlavorMatrix)
             assert np.allclose(matrix.array, np.eye(len(flavor)))
-
+    
     @staticmethod
     @pytest.mark.parametrize('flavor_in',flavor_schemes)
     @pytest.mark.parametrize('flavor_out',flavor_schemes)
@@ -151,3 +151,23 @@ class TestFlavorMatrix:
         assert isinstance(M, FlavorMatrix)
         assert M.flavor_in == flavor_in
         assert M.flavor_out == flavor_out
+
+    @staticmethod
+    @pytest.mark.parametrize('flavor_in',flavor_schemes)
+    @pytest.mark.parametrize('flavor_out',flavor_schemes)
+    def test_matrix_convert_to_flavor_method(flavor_in, flavor_out):
+        M =  FlavorMatrix.eye(ThreeFlavor,ThreeFlavor)
+        M1 = M.convert_to_flavor(flavor_in=flavor_in)
+        assert M1.flavor_in == flavor_in
+        assert M1.flavor_out == ThreeFlavor
+        M1 = M.convert_to_flavor(flavor_out=flavor_out)
+        assert M1.flavor_out == flavor_out
+        assert M1.flavor_in == ThreeFlavor
+        M1 = M.convert_to_flavor(flavor_in=flavor_in, flavor_out=flavor_out)
+        assert M1.flavor_in == flavor_in
+        assert M1.flavor_out == flavor_out
+        #test lshift conversion methods
+        assert flavor_out<<M == M.convert_to_flavor(flavor_out=flavor_out)
+        assert M<<flavor_in == M.convert_to_flavor(flavor_in=flavor_in)
+        assert flavor_out<<M<<flavor_in == M.convert_to_flavor(flavor_in=flavor_in, flavor_out=flavor_out)
+        

--- a/python/snewpy/test/test_flavors.py
+++ b/python/snewpy/test/test_flavors.py
@@ -25,7 +25,12 @@ class TestFlavorScheme:
             TwoFlavor['NU_MU']
         with pytest.raises(KeyError):
             ThreeFlavor['NU_X']
-            
+    @staticmethod
+    def test_getitem_collective_names():
+        assert ThreeFlavor['NU']==(ThreeFlavor.NU_E, ThreeFlavor.NU_MU, ThreeFlavor.NU_TAU)
+        assert ThreeFlavor['NU']==ThreeFlavor['e','mu','tau']
+        assert ThreeFlavor['NU_BAR']==(ThreeFlavor.NU_E_BAR, ThreeFlavor.NU_MU_BAR, ThreeFlavor.NU_TAU_BAR)
+        assert ThreeFlavor['NU_BAR']==ThreeFlavor['e_bar','mu_bar','tau_bar']
     @staticmethod
     def test_getitem_enum():
         assert TwoFlavor[TwoFlavor.NU_E] == TwoFlavor.NU_E
@@ -43,7 +48,7 @@ class TestFlavorScheme:
         TestFlavor = FlavorScheme.from_lepton_names('TestFlavor',leptons=['A','B','C'])
         assert len(TestFlavor)==6
         assert [f.name for f in TestFlavor]==['NU_A','NU_A_BAR','NU_B','NU_B_BAR','NU_C','NU_C_BAR']
-
+    
     @staticmethod
     def test_flavor_properties():
         f = ThreeFlavor.NU_E
@@ -104,7 +109,12 @@ class TestFlavorMatrix:
         assert m['NU_E','NU_X']==0
         assert np.allclose(m['NU_E'], [1,0,0,0])
         assert np.allclose(m['NU_E'], m['NU_E',:])
-        assert np.allclose(m[:,:], m.array)
+
+    @staticmethod
+    def test_getitem_submatrix():
+        m = FlavorMatrix.eye(TwoFlavor)
+        assert np.allclose(m[['e','x'],['e','x']], [[1,0],[0,1]])
+        assert np.allclose(m[:,:].array, m.array)
 
     @staticmethod
     def test_getitem_short():

--- a/python/snewpy/utils.py
+++ b/python/snewpy/utils.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def expand_dimensions_to(a:np.ndarray, ndim:int)->np.ndarray:
+    """Expand the dimensions of the array, adding dimensions of len=1 to the right,
+    so total dimensions equal to `ndim`"""
+    new_shape = (list(a.shape)+[1]*ndim)[:ndim]
+    return a.reshape(new_shape)


### PR DESCRIPTION
This is a first part of changes, needed for #344 

Expanding the interface of `FlavorScheme` and `FlavorMatrix` with useful methods and syntactic sugar. The goal is to make the code using these classes more expressive and look more similar to the formulas in the papers.
## Example
This allows us to access and define individual matrix elements as well as whole submatrices with a clear interface (example from #344 defining the elements of matrix in `mass_basis<<flavor_basis` space)
https://github.com/SNEWS2/snewpy/blob/818150348d8258ae0978434c644a0faf25069187/python/snewpy/neutrino.py#L178-L193

## Changes in `FlavorScheme`

1. Allowing to use shorter names for neutrinos, omitting `NU_` prefix. Also ignoring the case.
2. Adding the `'NU'` and `'NU_BAR'` names to access the list of all neutrinos or antineutrinos

## Changes in `FlavorMatrix`
1. Useful methods for complex matrix: `real`,`imag`,`abs`, `abs2`, `conjugate`
2. In the `__matmul__` method: added check if the flavor schemes of the matrices' dimensions are compatible. 
3. Adding the `extra_dims` options to constructors `FlavorMatrix.eye` and `FlavorMatrix.zeros` - to initialize arrays of size `(N x M x extra_dims)`. These extra dimensions can be energy and/or time dependency of the transformation
4. Added conversion methods: `convert_to_flavor` method, and also `<<` and `>>` operators, which allows to do the flavor bases conversion in one line, for example `M_3f = (ThreeFlavor<<M<<ThreeFlavor)`
5. Using `np.einsum` to perform the correct matrix multiplication of the matrices and matrix to flux
6. When creating conversion matrix, for example`(ThreeFlavor<<FourFlavor)`, it will check that the matrix is non-zero - to prevent silent zeroing out when there was an intrinsic conversion to an incompatible flavor scheme

See the changes in `test/test_flavors.py` for the demonstration of some new functionality