### PR TITLE
EOS deprecations

### DIFF
--- a/doc/nb/ccsn/Fischer_2020.ipynb
+++ b/doc/nb/ccsn/Fischer_2020.ipynb
@@ -36,23 +36,7 @@
    "source": [
     "## Initialize Models\n",
     "\n",
-    "To start, let’s see what progenitors are available for the `Fischer_2020` model. We can use the `param` property to view all physics parameters and their possible values:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Fischer_2020.param"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this case, there’s just a single progenitor available; so let’s initialize it. If this is the first time you’re using this progenitor, snewpy will automatically download the required data files for you."
+    "For the `Fischer_2020` model, there’s just a single progenitor available; so let’s initialize it. If this is the first time you’re using this progenitor, snewpy will automatically download the required data files for you."
    ]
   },
   {

--- a/python/snewpy/models/ccsn.py
+++ b/python/snewpy/models/ccsn.py
@@ -126,6 +126,7 @@ class Sukhbold_2015(loaders.Sukhbold_2015):
         return super().__init__(filename, self.metadata)
 
 
+@deprecated('eos')
 @legacy_filename_initialization
 @RegistryModel(
     progenitor_mass = [11.2, 20., 27.] * u.Msun,
@@ -144,6 +145,8 @@ class Tamborra_2014(loaders.Tamborra_2014):
         # Metadata is handled by __init__ in _GarchingArchiveModel
         return super().__init__(filename=filename, metadata=self.metadata)
 
+
+@deprecated('eos')
 @legacy_filename_initialization
 @RegistryModel(
     progenitor_mass= [11.2, 27.] * u.Msun,
@@ -157,6 +160,8 @@ class Bollig_2016(loaders.Bollig_2016):
         filename = f's{progenitor_mass.value:3.1f}c'
         return super().__init__(filename=filename, metadata=self.metadata)
 
+
+@deprecated('eos')
 @legacy_filename_initialization
 @RegistryModel(
     progenitor_mass = [15.] * u.Msun,
@@ -175,6 +180,7 @@ class Walk_2018(loaders.Walk_2018):
         return super().__init__(filename=filename, metadata=self.metadata)
 
 
+@deprecated('eos')
 @legacy_filename_initialization
 @RegistryModel(
     progenitor_mass = [40., 75.] * u.Msun,

--- a/python/snewpy/models/ccsn.py
+++ b/python/snewpy/models/ccsn.py
@@ -44,15 +44,14 @@ from snewpy.models.registry_model import deprecated, legacy_filename_initializat
 from snewpy.models.registry_model import all_models
 from textwrap import dedent
 
-@legacy_filename_initialization
-@RegistryModel(
-    progenitor_mass= [18 * u.Msun],
-    eos = ['HS(DD2)']
-)
+
+@RegistryModel()
 class Fischer_2020(loaders.Fischer_2020):
     """Model based on simulations from `Fischer et al. (2020) <https://arxiv.org/abs/1804.10890>`
     """
-    def __init__(self, progenitor_mass:u.Quantity, eos:str):
+    def __init__(self):
+        self.metadata["EOS"] = "HS(DD2)"
+        self.metadata["Progenitor mass"] = 18 * u.Msun
         filename='Fischer_2020.tar.gz'
         return super().__init__(filename, metadata=self.metadata)
 


### PR DESCRIPTION
Working on #356 I noticed that there were a few more SN model classes that had only a single option for the `eos` argument but where it wasn’t marked as `@deprecated`. This PR adds deprecation markers to those models; in line with the docstring of the `GarchingArchiveModel` class (which these four models all inherit from).

For the `Fischer_2020` model, which was just added in #347, I’m also moving the `eos` argument to a metadata field. (No deprecation necessary here, because this was never in a published release.)