### PR TITLE
Support Python 3.13 (and drop 3.8)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         # Test all supported Python versions under Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # Additionally, test one Python version under MacOS and Windows, to detect OS-specific issues
         include:
           - os: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # Test all supported Python versions under Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # Additionally, test one Python version under MacOS and Windows, to detect OS-specific issues
         include:
           - os: macos-latest

--- a/python/snewpy/snowglobes_interface.py
+++ b/python/snewpy/snowglobes_interface.py
@@ -18,10 +18,7 @@ from tqdm.auto import tqdm
 
 import snowglobes_data
 import sys
-if sys.version_info >= (3, 9):
-    from importlib.resources import files
-else:
-    from importlib_resources import files
+from importlib.resources import files
 
 def guess_material(detector):
     if detector.startswith(('wc', 'ice', 'km3net')):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ h5py
 requests
 pyyaml
 snowglobes_data == 1.3.2
-importlib_resources; python_version < "3.9"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.md'):
 # See https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 # setup_keywords['entry_points'] = {'console_scripts': ['to_snowglobes = snewpy.to_snowglobes:generate_time_series', ], },
 setup_keywords['provides'] = [setup_keywords['name']]
-setup_keywords['python_requires'] = '>=3.8'
+setup_keywords['python_requires'] = '>=3.9'
 setup_keywords['zip_safe'] = False
 setup_keywords['packages'] = find_packages('python')
 setup_keywords['package_dir'] = {'': 'python'}


### PR DESCRIPTION
Python 3.13 was released last week and 3.8 [reached end-of-life](https://devguide.python.org/versions/) at the same time. This PR updates our testing matrix accordingly and removes some compatibility workarounds that are no longer necessary.