### PR TITLE
Adding version checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # Set up the Python environment and dependencies
       - name: Set up Python ${{ matrix.python-version }}

--- a/python/snewpy/test/test_00_init.py
+++ b/python/snewpy/test/test_00_init.py
@@ -1,7 +1,14 @@
 import snewpy
-import unittest
+import importlib
+import subprocess
 
+def test_version_exists():
+    assert hasattr(snewpy, '__version__')
 
-class TestInit(unittest.TestCase):
-    def test_version_exists(self):
-        self.assertTrue(hasattr(snewpy, '__version__'))
+def test_version_is_consistent_with_variable():
+    assert importlib.metadata.version('snewpy') == snewpy.__version__
+
+def test_version_is_consistent_with_git_tag():
+    git_tag = subprocess.check_output('git describe --abbrev=0'.split())
+    git_tag = git_tag.decode('ascii').strip().lstrip('v')
+    assert git_tag == snewpy.__version__


### PR DESCRIPTION
This PR adds two new initial checks, to make sure that our versions are consistent in different places: 
* `snewpy.__version__`
* `importlib.metadata.version` (the one set via `pip install`)
* current git tag (`git describe --abbrev=0`), after removing the `v` prefix