### PR TITLE
Initializing all preSN models with negative time

### DIFF
--- a/python/snewpy/models/presn_loaders.py
+++ b/python/snewpy/models/presn_loaders.py
@@ -97,7 +97,7 @@ class Patton_2017(SupernovaModel):
         self.interpolated = _interp_TE(
             times, energies, self.array, ax_t=1, ax_e=2
         )
-        super().__init__(times << u.hour, self.metadata)
+        super().__init__(-times << u.hour, self.metadata)
 
     def get_initial_spectra(self, t, E, flavors=Flavor):
         t = np.array(-t.to_value("hour"), ndmin=1)
@@ -131,7 +131,7 @@ class Kato_2017(SupernovaModel):
         self.interpolated = _interp_TE(
             times, energies, self.array, ax_t=1, ax_e=2
         )
-        super().__init__(times << u.s, self.metadata)
+        super().__init__(-times << u.s, self.metadata)
 
     def get_initial_spectra(self, t, E, flavors=Flavor):
         t = np.array(-t.to_value("s"), ndmin=1)
@@ -164,7 +164,7 @@ class Yoshida_2016(SupernovaModel):
         self.interpolated = _interp_TE(
             times, energies, dNdEdT, ax_t=1, ax_e=2
         )
-        super().__init__(times << u.s, self.metadata)
+        super().__init__(-times << u.s, self.metadata)
 
     def get_initial_spectra(self, t, E, flavors=Flavor):
         t = np.array(-t.to_value("s"), ndmin=1)


### PR DESCRIPTION
Our supernova models have `SupernovaModel.time` attribute which contains the intrinsic time values - which in many cases define the valid time range of the given model.

For the presupernova models this time range should be negative (i.e. time before collapse).
But currently `.time` is negative only for Odrzywolek, and positive for all others.

This PR corrects that. 