### PR TITLE
`Odrzywolek_2010`: accept scalar energies in `get_initial_spectra`

### DIFF
--- a/python/snewpy/models/presn_loaders.py
+++ b/python/snewpy/models/presn_loaders.py
@@ -61,8 +61,8 @@ class Odrzywolek_2010(SupernovaModel):
 
     def get_initial_spectra(self, t, E, flavors=Flavor):
         # negative t for time before SN
-        t = -t.to_value("s")
-        E = E.to_value("MeV")
+        t = np.array(-t.to_value("s"), ndmin=1)
+        E = np.array(E.to_value("MeV"), ndmin=1)
         df = self.df_t(t)
         a, alpha, b = df.T
         Enu = np.expand_dims(E, 1)


### PR DESCRIPTION
Fixes #395.

Cast `t` and `E` to `np.array` up front, like in all the other model subclasses. This now gives the same results for both calls:
```Python
model.get_initial_spectra(-10*u.s, 3*u.MeV)  # <-- this failed before the PR
model.get_initial_spectra(-10*u.s, np.expand_dims(3*u.MeV, axis=0))
```
