### PR TITLE
Initializing the mixing_parameters in the c-tors

### DIFF
--- a/python/snewpy/flavor_transformation/TransformationChain.py
+++ b/python/snewpy/flavor_transformation/TransformationChain.py
@@ -25,8 +25,8 @@ class TransformationChain(FlavorTransformation):
     """
     def __init__(self,
                  in_sn: SNTransformation,
-                 in_vacuum: VacuumTransformation=NoVacuumTransformation(),
-                 in_earth: EarthTransformation=NoEarthMatter(),
+                 in_vacuum: VacuumTransformation|None=None,
+                 in_earth: EarthTransformation|None=None,
                  *,
                  mixing_params:ThreeFlavorMixingParameters|FourFlavorMixingParameters=MixingParameters()
                 ):
@@ -37,15 +37,18 @@ class TransformationChain(FlavorTransformation):
             Transformation in Supernova.
         in_vacuum
             Transformation in Vacuum.
-            By default NoVacuumTransformation is applied
+            If None (default) NoVacuumTransformation is applied
         in_earth
             Transformation in Earth.
-            By default NoEarthTransformation is applied
+            If None (default) NoEarthTransformation is applied
 
         Keyword mixing_params
             Neutrino mixing parameters (to be applied to all individual transformations in chain)
             By default use standard `MixingParameters` with normal neutrino ordering
         """
+        in_vacuum = in_vacuum or NoVacuumTransformation()
+        in_earth = in_earth or NoEarthMatter()
+
         self.transforms = TransformationsTuple(in_sn, in_vacuum, in_earth)
         self.set_mixing_params(mixing_params)
     

--- a/python/snewpy/flavor_transformation/base.py
+++ b/python/snewpy/flavor_transformation/base.py
@@ -5,8 +5,8 @@ from snewpy.flavor import FlavorMatrix
 from snewpy.neutrino import MixingParameters, ThreeFlavorMixingParameters, FourFlavorMixingParameters
 
 class ThreeFlavorTransformation:
-    _mixing_params = ThreeFlavorMixingParameters(**MixingParameters())
-    
+    def __init__(self, mixing_params:ThreeFlavorMixingParameters|None = None):
+        self._mixing_params = mixing_params or ThreeFlavorMixingParameters(**MixingParameters())
     @property
     def mixing_params(self):
         return self._mixing_params
@@ -16,8 +16,8 @@ class ThreeFlavorTransformation:
         return self._mixing_params.update(**val)
 
 class FourFlavorTransformation(ThreeFlavorTransformation):
-    _mixing_params = FourFlavorMixingParameters(**MixingParameters())
-
+        def __init__(self, mixing_params:FourFlavorMixingParameters|None = None):
+            self._mixing_params = mixing_params or FourFlavorMixingParameters(**MixingParameters())
 
 class FlavorTransformation(ABC):
     """Generic interface to compute neutrino and antineutrino survival probability."""

--- a/python/snewpy/flavor_transformation/in_earth.py
+++ b/python/snewpy/flavor_transformation/in_earth.py
@@ -31,9 +31,9 @@ class EarthTransformation(ABC):
         pass
 ###############################################################################
 
-class NoEarthMatter(EarthTransformation):
+class NoEarthMatter(ThreeFlavorTransformation, EarthTransformation):
     def __init__(self, mixing_params=None):
-         self.mixing_params = mixing_params or MixingParameters('NORMAL')
+        super().__init__(mixing_params or MixingParameters('NORMAL'))
          
     def P_fm(self, t, E)->FlavorMatrix:
         D = self.mixing_params.VacuumMixingMatrix().abs2()
@@ -50,10 +50,9 @@ class EarthMatter(ThreeFlavorTransformation, EarthTransformation):
         mixing_params : ThreeFlavorMixingParameters instance or None
         SNAltAz : astropy AltAz object
         """       
+        super().__init__(mixing_params)
         if BEMEWS is None:
             raise ModuleNotFoundError('BEMEWS module is not found. Please make sure BEMEWS is installed to use EarthMatter transformation')
-        if(mixing_params):
-            self.mixing_params=mixing_params
         self.SNAltAz = SNAltAz
 
         self.prior_E = None # used to store energy array from previous calls to get_probabilities

--- a/python/snewpy/flavor_transformation/in_sn.py
+++ b/python/snewpy/flavor_transformation/in_sn.py
@@ -94,6 +94,7 @@ class MSWEffect(SNTransformation, ThreeFlavorTransformation):
         ----------
         SNprofile : instance of profile class
         """
+        super().__init__()
         if SNOSHEWS == None:
             raise ModuleNotFoundError("The SNOSHEWS module not be found. Please make sure SNOSHEWS is installed to use MSWEffect transformation")
         #input data object for SNOSHEWS

--- a/python/snewpy/flavor_transformation/in_vacuum.py
+++ b/python/snewpy/flavor_transformation/in_vacuum.py
@@ -42,10 +42,11 @@ class NeutrinoDecay(VacuumTransformation, ThreeFlavorTransformation):
         dist : astropy.units.quantity.Quantity
             Distance to the supernova.
         """
+        super().__init__()
         self.m = mass
         self.tau = tau
         self.d = dist
-
+        
     def gamma(self, E):
         """Decay width of the heaviest neutrino mass.
 
@@ -104,6 +105,7 @@ class QuantumDecoherence(VacuumTransformation, ThreeFlavorTransformation):
             it is taken as 10 MeV. Note that if n = 0, quantum decoherence parameters are independent
             of E0.
         """
+        super().__init__()
         self.Gamma3 = (Gamma3 / (c.hbar.to('eV s') * c.c)).to('1/kpc')
         self.Gamma8 = (Gamma8 / (c.hbar.to('eV s') * c.c)).to('1/kpc')
         self.d = dist


### PR DESCRIPTION
There was a problem in `Three/FourFlavorTransformation` class - the `mixing_params` used to be a static (class) variable. That means that creating two instances of the same class with different mixing parameters, those will be overwritten:
```python
import snewpy.flavor_transformation as flx
from snewpy.neutrino import MixingParameters

msw_NMO = flx.AdiabaticMSW(MixingParameters('NORMAL'))
msw_IMO = flx.AdiabaticMSW(MixingParameters('INVERTED'))
print(id(msw_NMO.transforms.in_sn.mixing_params) == id(msw_IMO.transforms.in_sn.mixing_params))
#True - before this PR
```

I fix it by adding explicit constructor `__init__(mixing_pars)` which initializes the parameters.

The downside of this is that, as always, any subclass of `Three/FourFlavorTransformation` must call `super().__init__()`.