### PR TITLE
create data loader class for Myers_2026 presn models

### DIFF
--- a/python/snewpy/models/model_files.yml
+++ b/python/snewpy/models/model_files.yml
@@ -6,6 +6,7 @@ config:
     - &snewpy "https://github.com/SNEWS2/snewpy/raw/v{snewpy_version}/models/{model}/{filename}"
     - &ccsn_repository "https://github.com/SNEWS2/snewpy-models-ccsn/raw/v0.3/models/{model}/{filename}"
     - &presn_repository "https://github.com/SNEWS2/snewpy-models-presn/raw/v0.2/models/{model}/{filename}"
+    - &presn_repository_main "https://github.com/SNEWS2/snewpy-models-presn/raw/master/models/{model}/{filename}"
     
 models:
     ccsn:
@@ -76,3 +77,6 @@ models:
 
         Yoshida_2016:
             repository: *presn_repository
+
+        Myers_2026:
+            repository: *presn_repository_main

--- a/python/snewpy/models/presn.py
+++ b/python/snewpy/models/presn.py
@@ -59,3 +59,19 @@ class Yoshida_2016(loaders.Yoshida_2016):
     def __init__(self, progenitor_mass:u.Quantity):
         path=f"t_spc_m{progenitor_mass.to_value('Msun'):.0f}_1.2.txt"
         super().__init__(path, self.metadata)
+
+@RegistryModel(
+    progenitor_mass = [12, 15, 18, 20]<<u.Msun,
+    eta = [0.2, 0.4, 0.8, 1.0],
+    bounds = ['all', 'core']
+)
+class Myers_2026(loaders.Myers_2026):
+    """Presupernova model based on 
+    [Myers et al. (2026) arxiv.org/abs/2604.22605]
+    
+    Dataset available on `GitHub <https://github.com/SNEWS2/snewpy-models-presn/tree/main/models/Myers_2026>`__
+    """
+    def __init__(self, progenitor_mass:u.Quantity, eta:float, bounds:str):
+        path=f"{progenitor_mass.to_value('Msun'):.0f}M_{eta:.1f}_{bounds}.zip"
+        super().__init__(path, self.metadata)
+        

--- a/python/snewpy/models/presn_loaders.py
+++ b/python/snewpy/models/presn_loaders.py
@@ -193,7 +193,8 @@ class Myers_2026(SupernovaModel):
     _T_CC_RE = re.compile(r"t_cc\s*=\s*([-+0-9.eE]+)") # regex pattern to find t_cc in header of files
 
 
-    def __init__(self, filename, metadata={}):                                                             
+    def __init__(self, filename, metadata={}):         
+                                                                                                       
         datafile = self.request_file(filename)    
         with zipfile.ZipFile(datafile) as zf:
             beta_names = sorted(n for n in zf.namelist()                                                                                                                     
@@ -206,8 +207,9 @@ class Myers_2026(SupernovaModel):
             pair = {self._profile(n): self._read_snapshot(zf, n) for n in pair_names}  
 
  
-        profiles = sorted(beta.keys() & pair.keys(), key=lambda k: beta[k][0])  # sort by t_cc, make sure to align across beta and pair processes                                                                                                                                                                    
-        times = np.array([beta[k][0] for k in profiles])                                                                                                      
+        profiles = sorted(beta.keys() & pair.keys(), key=lambda k: beta[k][0])  # sort by t_cc, make sure to align across beta and pair processes
+        profiles = [k for k in profiles if beta[k][0] >= -1000]  # keep only last 1000 hours before collapse
+        times = np.array([beta[k][0] for k in profiles])
         energies = np.array(beta[profiles[0]][1]) # all profiles have the same energy grid, just take the first                                                                                                                                                                       
 
         nu_e      = np.stack([beta[k][2][:, 0] + pair[k][2][:, 0] for k in profiles])  # (nT, nE)
@@ -220,9 +222,9 @@ class Myers_2026(SupernovaModel):
         dNdEdT = np.stack([nu_e, nu_e_bar, nu_mu, nu_mu_bar, nu_tau, nu_tau_bar], axis=0)
 
         self.interpolated = _interp_TE(
-            times, energies, dNdEdT, ax_t=1, ax_e=2
+            np.abs(times), energies, dNdEdT, ax_t=1, ax_e=2
         )
-        super().__init__(-times << u.hour, metadata)
+        super().__init__(times << u.hour, metadata)
 
     @classmethod
     def _read_snapshot(cls, zf, name):                                                                                                                                            

--- a/python/snewpy/models/presn_loaders.py
+++ b/python/snewpy/models/presn_loaders.py
@@ -12,6 +12,10 @@ from snewpy.models.base import SupernovaModel
 from snewpy.flavor import ThreeFlavor
 from pathlib import Path
 
+import io
+import re
+import zipfile
+
 def _interp_T(t0, v0, dt=1e-3, dv=1e-10, axis=0):
     "dilog interpolation"
     lt0 = np.log(t0 + dt)
@@ -178,6 +182,64 @@ class Yoshida_2016(SupernovaModel):
 
     def _get_initial_spectra_dict(self, t, E, flavors=ThreeFlavor):
         t = np.array(-t.to_value("s"), ndmin=1)
+        E = np.array(E.to_value("MeV"), ndmin=1)
+        flux = self.interpolated(t, E) / (u.MeV * u.s)
+        return {f: flux[f] for f in flavors}
+    
+class Myers_2026(SupernovaModel):
+    """Set up a presupernova model based on 
+    [Myers et al. (2026) arxiv.org/abs/2604.22605]
+    """
+    _T_CC_RE = re.compile(r"t_cc\s*=\s*([-+0-9.eE]+)") # regex pattern to find t_cc in header of files
+
+
+    def __init__(self, filename, metadata={}):                                                             
+        datafile = self.request_file(filename)    
+        with zipfile.ZipFile(datafile) as zf:
+            beta_names = sorted(n for n in zf.namelist()                                                                                                                     
+                                if "/betaLuminosity/" in n and n.endswith(".dat"))
+            pair_names = sorted(n for n in zf.namelist()                                                                                                                     
+                                if "/pairLuminosity/" in n and n.endswith(".dat"))
+                                                                                                                                                                            
+            # create dictionaries for beta and pair processes. keys are MESA profile numbers, entries are t_cc, energy, spectral data                                                                                     
+            beta = {self._profile(n): self._read_snapshot(zf, n) for n in beta_names}
+            pair = {self._profile(n): self._read_snapshot(zf, n) for n in pair_names}  
+
+ 
+        profiles = sorted(beta.keys() & pair.keys(), key=lambda k: beta[k][0])  # sort by t_cc, make sure to align across beta and pair processes                                                                                                                                                                    
+        times = np.array([beta[k][0] for k in profiles])                                                                                                      
+        energies = np.array(beta[profiles[0]][1]) # all profiles have the same energy grid, just take the first                                                                                                                                                                       
+
+        nu_e      = np.stack([beta[k][2][:, 0] + pair[k][2][:, 0] for k in profiles])  # (nT, nE)
+        nu_e_bar  = np.stack([beta[k][2][:, 1] + pair[k][2][:, 1] for k in profiles])                                                                                                
+        nu_mu     = np.stack([pair[k][2][:, 2] for k in profiles])  # beta contributes 0
+        nu_mu_bar = np.stack([pair[k][2][:, 3] for k in profiles])                                                                                               
+        nu_tau    = nu_mu                                           # mu = tau                                                                                                                  
+        nu_tau_bar= nu_mu_bar
+
+        dNdEdT = np.stack([nu_e, nu_e_bar, nu_mu, nu_mu_bar, nu_tau, nu_tau_bar], axis=0)
+
+        self.interpolated = _interp_TE(
+            times, energies, dNdEdT, ax_t=1, ax_e=2
+        )
+        super().__init__(-times << u.hour, metadata)
+
+    @classmethod
+    def _read_snapshot(cls, zf, name):                                                                                                                                            
+        with zf.open(name) as f:
+            text = io.TextIOWrapper(f, encoding="utf-8").read() 
+        t_cc = float(cls._T_CC_RE.search(text).group(1))        # get the time to collapse in hours from the file headers                                                                                                               
+        data = np.loadtxt(io.StringIO(text), comments="#")  
+        if data[0, 0] == 0.0:                                                                                                                                                    
+            data = data[1:]                       # drop the energy=0 row                                                                                                                
+        return t_cc, data[:, 0], data[:, 1:]
+
+    @staticmethod                                                                                                                                                            
+    def _profile(name):                                                                                                                                                      
+        return int(re.search(r"LuminosityProfile(\d+)\.dat$", name).group(1))
+
+    def _get_initial_spectra_dict(self, t, E, flavors=ThreeFlavor):
+        t = np.array(-t.to_value("hour"), ndmin=1)
         E = np.array(E.to_value("MeV"), ndmin=1)
         flux = self.interpolated(t, E) / (u.MeV * u.s)
         return {f: flux[f] for f in flavors}

--- a/python/snewpy/test/test_presn_rates.py
+++ b/python/snewpy/test/test_presn_rates.py
@@ -15,11 +15,17 @@ distance = 200*u.pc
 T = np.geomspace(-1*u.hour, -1*u.min,1000)
 E = np.linspace(0,20,100)*u.MeV
 
-@pytest.mark.parametrize('model_class',[presn.Odrzywolek_2010, presn.Kato_2017, presn.Patton_2017, presn.Yoshida_2016])
+@pytest.mark.parametrize('model_class,model_params',[
+    (presn.Odrzywolek_2010, {'progenitor_mass': 15*u.Msun}),
+    (presn.Kato_2017, {'progenitor_mass': 15*u.Msun}),
+    (presn.Patton_2017, {'progenitor_mass': 15*u.Msun}),
+    (presn.Yoshida_2016, {'progenitor_mass': 15*u.Msun}),
+    (presn.Myers_2026, {'progenitor_mass': 15*u.Msun, 'eta': 0.8, 'bounds': 'core'}),
+])
 @pytest.mark.parametrize('transformation',[AdiabaticMSW(MixingParameters(mh)) for mh in MassHierarchy])
 @pytest.mark.parametrize('detector', ["wc100kt30prct"])
-def test_presn_rate(model_class, transformation, detector):
-    model = model_class(progenitor_mass=15*u.Msun)
+def test_presn_rate(model_class, model_params, transformation, detector):
+    model = model_class(**model_params)
     flux = model.get_flux(T, E, distance=distance, flavor_xform=transformation)
     rate = rc.run(flux, detector='scint20kt', detector_effects=False)['ibd']
     ibd_events = rate.integrate_or_sum('time').integrate_or_sum('energy').array.squeeze()


### PR DESCRIPTION
New class created in presn_loaders.py and presn.py called Myers_2026.  The models have three parameters: progenitor_mass, eta, and bounds.  The possible values are progenitor_mass = {12,15,18,20}, eta = {0.2,0.4,0.8,1.0}, and bounds = {'all','core'}.  

Data is stored on snewpy-models-presn/models/Myers_2026 in zip files.  The loader reads in the spectra for different time snapshots, pulls the time to collapse from the header of the files, and adds the beta process and pair process spectra at each of those times.  Interpolations over time and energy are done as for other models.  

The end result is an array of time, energy, and dNdTdE for e, mu, tau flavors and their antineutrinos.

Note:  since the presn models already included were grabbed from a previous release that does not include Myers_2026, I added a new line to model_files.yaml so that the data will be pulled from the master branch of snewpy-models-presn.