### PR TITLE
Minimise matplotlib version exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "astropy-healpix >= 1.1",
     "pandas",
     "tqdm",
-    "matplotlib < 3.11",
+    "matplotlib != 3.11.0",
     "h5py",
     "requests",
     "pyyaml",

--- a/python/snewpy/models/model_files.yml
+++ b/python/snewpy/models/model_files.yml
@@ -6,7 +6,7 @@ config:
     - &snewpy "https://github.com/SNEWS2/snewpy/raw/v{snewpy_version}/models/{model}/{filename}"
     - &ccsn_repository "https://github.com/SNEWS2/snewpy-models-ccsn/raw/v0.4/models/{model}/{filename}"
     - &presn_repository "https://github.com/SNEWS2/snewpy-models-presn/raw/v0.2/models/{model}/{filename}"
-    - &presn_repository_main "https://github.com/SNEWS2/snewpy-models-presn/raw/master/models/{model}/{filename}"
+    - &presn_repository_main "https://github.com/SNEWS2/snewpy-models-presn/raw/main/models/{model}/{filename}"
     
 models:
     ccsn:


### PR DESCRIPTION
Closes #436. Fix was already done in the matplotlib repo and will be included in the upcoming 3.11.1 release.