### PR TITLE
Add tests and notebooks for `Takata_2025` models

### DIFF
--- a/doc/source/nb/ccsn/Takata_2025.ipynb
+++ b/doc/source/nb/ccsn/Takata_2025.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "04bf2ca6",
+   "metadata": {},
+   "source": [
+    "# Takata 2025 2D Models with Axionlike Production\n",
+    "\n",
+    "Neutrino data for 1-D core-collapse supernova models in the presence of axion-like particles.\n",
+    "\n",
+    "The reference article is [Progenitor dependence of neutrino-driven supernova explosions with the aid of heavy axionlike particles](https://doi.org/10.1103/PhysRevD.111.103028) by T. Takata et al., Phys. Rev. D 111:103028, 2025.\n",
+    "\n",
+    "The following models are supported:\n",
+    "\n",
+    "## ALP parameters and progenitor masses simulated\n",
+    "\n",
+    "| Progenitor mass [Msun] | Axion mass [MeV] | Axion-photon coupling [1e-10/GeV] |\n",
+    "| ---------------------- | ---------------- | --------------------------------- |\n",
+    "| 11.2 | 0, 40, 100, 150, 200, 300, 400, 600, 800 | 0, 2, 4, 6, 8, 10 |\n",
+    "| 20 | 0, 40, 100, 150, 200, 300, 400, 600, 800 | 0, 2, 4, 6, 8, 10 |\n",
+    "| 25 | 0, 40, 100, 150, 200, 300, 400, 600, 800 | 0, 2, 4, 6, 8, 10 |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "29ceae1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snewpy.neutrino import Flavor\n",
+    "from snewpy.models.ccsn import Takata_2025\n",
+    "\n",
+    "from astropy import units as u\n",
+    "\n",
+    "from scipy.interpolate import PchipInterpolator\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1b7566ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mpl.rc('font', size=16)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66d13225",
+   "metadata": {},
+   "source": [
+    "## Initialize the 2D models\n",
+    "\n",
+    "Use the `param` property of the model class to see the available parameters. Models are initialized using the `axion_mass` and `axion_coupling` parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f62e690f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'progenitor_mass': <Quantity [11.2, 20. , 25. ] solMass>,\n",
+       " 'axion_mass': <Quantity [  0.,  40., 100., 150., 200., 300., 400., 600., 800.] MeV>,\n",
+       " 'axion_coupling': <Quantity [ 0.,  2.,  4.,  6.,  8., 10.] 1e-10 / GeV>}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Takata_2025.param"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55479166",
+   "metadata": {},
+   "source": [
+    "The model with `axion_mass=0` and `axion_coupling=0` is a standard simulation with no ALP production.\n",
+    "\n",
+    "We'll use the model with a 25 M$_\\odot$ progenitor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "649f5ae4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Takata_2025 Model**: 25_000_00.dat\n"
+      ],
+      "text/plain": [
+       "Takata_2025 Model: 25_000_00.dat"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_std = Takata_2025(axion_mass=0, axion_coupling=0, progenitor_mass=25*u.Msun)\n",
+    "model_std"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f15de7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize a handful of axion models.\n",
+    "models = {}\n",
+    "for (am, ac) in ((100*u.MeV, 2e-10/u.GeV), (200*u.MeV,2e-10/u.GeV), (100*u.MeV,10e-10/u.GeV), (100*u.MeV,20e-10/u.GeV), (200*u.MeV,10e-10/u.GeV), (200*u.MeV,20e-10/u.GeV)):\n",
+    "    models[(am,ac)] = Mori_2023(axion_mass=am, axion_coupling=ac)\n",
+    "\n",
+    "models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cab5a9c",
+   "metadata": {},
+   "source": [
+    "## Plot Model Luminosities\n",
+    "\n",
+    "Compare axion model luminosity to the standard 2D simulation.\n",
+    "\n",
+    "Higher mass models with stronger coupling constants should produce a decrease in neutrino luminosity at all flavors relative to the reference simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a398333",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for (m,c), model in models.items():\n",
+    "    \n",
+    "    fig, axes = plt.subplots(2, 6, figsize=(40, 8), sharex=True,\n",
+    "                         gridspec_kw={'height_ratios':[3.2,1], 'hspace':0, 'wspace':0.05})\n",
+    "    \n",
+    "    Lmin,  Lmax  = 1e99, -1e99\n",
+    "    dLmin, dLmax = 1e99, -1e99\n",
+    "    \n",
+    "    for j, (flavor) in enumerate(Flavor):\n",
+    "        ax = axes[0][j]\n",
+    "        \n",
+    "        ax.plot(model_std.time, model_std.luminosity[flavor]/1e51, 'k', label=r'$20M_\\odot$ reference')  # Report luminosity in [foe/s]\n",
+    "        Lmin = np.minimum(Lmin, np.min(model_std.luminosity[flavor].to_value('1e51 erg/s')))\n",
+    "        Lmax = np.maximum(Lmax, np.max(model_std.luminosity[flavor].to_value('1e51 erg/s')))\n",
+    "        \n",
+    "        modlabel = rf\"{flavor.to_tex()}: $m_a=${m.to_string(format='latex_inline')}\" + \"\\n\" + rf\"     $g_{{a\\gamma}}=${c.to_string(format='latex_inline')}\"\n",
+    "        ax.plot(model.time, model.luminosity[flavor]/1e51,  # Report luminosity in units foe/s\n",
+    "                label=modlabel,\n",
+    "                color='C0' if flavor.is_electron else 'C1',\n",
+    "                ls='-' if flavor.is_neutrino else ':',\n",
+    "                lw=2)\n",
+    "        if j==0:\n",
+    "            ax.set(ylabel=r'luminosity [$10^{51}$ erg s$^{-1}$]')\n",
+    "        \n",
+    "        ax.legend(fontsize=12)\n",
+    "        ax.set(xlim=(model_std.time[0].to_value('s'), model_std.time[-1].to_value('s')))\n",
+    "        \n",
+    "        ax = axes[1][j]\n",
+    "        tmin = np.maximum(model.time[0], model_std.time[0]).to_value('s')\n",
+    "        tmax = np.minimum(model.time[-1], model_std.time[-1]).to_value('s')\n",
+    "        times = np.arange(tmin, tmax, 0.001)*u.s\n",
+    "\n",
+    "        Lstd = PchipInterpolator(model_std.time, model_std.luminosity[flavor].to_value('1e51 erg/s'))\n",
+    "        Lstd_t = Lstd(times)\n",
+    "        select = Lstd_t != 0\n",
+    "        \n",
+    "        Lmod = PchipInterpolator(model.time, model.luminosity[flavor].to_value('1e51 erg/s'))\n",
+    "        Lmod_t = Lmod(times)\n",
+    "        dL = (Lmod_t[select] - Lstd_t[select]) / Lstd_t[select]\n",
+    "        \n",
+    "        dLmin = np.minimum(dLmin, np.min(dL))\n",
+    "        dLmax = np.maximum(dLmax, np.max(dL))\n",
+    "\n",
+    "        ax.plot(times[select], dL)\n",
+    "        if j==0:\n",
+    "            ax.set(xlabel='time [s]',\n",
+    "                   ylabel=r'$\\Delta L_\\nu/L_\\nu$')\n",
+    "            \n",
+    "    for j in range(6):\n",
+    "        axes[0][j].set(ylim=(Lmin, 1.1*Lmax))\n",
+    "        axes[1][j].set(ylim=(dLmin, dLmax))\n",
+    "        if j > 0:\n",
+    "            axes[0][j].set_yticklabels([])\n",
+    "            axes[1][j].set_yticklabels([])\n",
+    "        \n",
+    "    fig.suptitle(rf\"Axionlike model: $m_a=${m.to_string(format='latex_inline')}, $g_{{a\\gamma}}=${c.to_string(format='latex_inline')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eabc4b8e-3b43-4c22-bd23-17ff73707a08",
+   "metadata": {},
+   "source": [
+    "## Plot Model Spectra\n",
+    "\n",
+    "Plot model spectra for the baseline model and a few of the alternative models for several times. Assume the progenitor is at a distance of 1 kpc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cd83985-a0ed-42b5-84ac-378a346595ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t = np.arange(0.05, 0.3, 0.05) * u.s\n",
+    "E = np.arange(0, 50.1, 0.1) * u.MeV\n",
+    "d = 1*u.kpc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d74a1fc-3e16-49df-920b-a4ca3f263d9f",
+   "metadata": {},
+   "source": [
+    "### Compare Baseline Model to 100 MeV ALP\n",
+    "\n",
+    "Show the spectra from the ALP model at several times. The baseline model (no ALP) spectra are drawn as dashed lines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc54866f-bbcc-47e2-bba6-6234e0455fa7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nt = t.shape[0]\n",
+    "\n",
+    "fig, axes = plt.subplots(1,2, figsize=(10,4.5), sharex=True, tight_layout=True)\n",
+    "\n",
+    "fmin, fmax = 0, -1e99\n",
+    "\n",
+    "for fl in (Flavor.NU_E, Flavor.NU_E_BAR):\n",
+    "    ax = axes[fl]\n",
+    "\n",
+    "    for j in np.arange(nt):\n",
+    "        color = None\n",
+    "        for i, model in enumerate([model_std, models[(100*u.MeV,10e-10/u.GeV)]]):\n",
+    "            d2fdEdt = model.get_flux(t, E, d)\n",
+    "            dfdE = d2fdEdt.array[fl, j, :].to_value('1e12/(MeV s cm2)')\n",
+    "            fmax = np.maximum(fmax, np.max(dfdE))\n",
+    "            ls = '--' if i == 0 else '-'\n",
+    "            label = None if i == 0 else rf'$t_\\text{{pb}}={t[j].to_value(\"ms\"):g}$ ms'\n",
+    "            width = 1 if i==0 else 1.5\n",
+    "            line, = ax.plot(E, dfdE, label=label, ls=ls, lw=width, color=color)\n",
+    "            color = line.get_color()\n",
+    "\n",
+    "    ax.set(xlim=E[[0,-1]].to_value(),\n",
+    "           xlabel='energy [MeV]',\n",
+    "           ylim=(fmin, 1.1*fmax),\n",
+    "           ylabel=rf'$\\Phi_{{{fl.to_tex()[1:-1]}}}$ [$10^{{12}}$ MeV$^{{-1}}$ s$^{{-1}}$ m$^{{-2}}$]',\n",
+    "          )\n",
+    "    ax.set_title(rf'$m_a=\\text{{{model.metadata[\"Axion mass\"]}}}$, $g_{{a\\gamma}}={model.metadata[\"Axion coupling\"].to_value(\"1e-10/GeV\")}\\times10^{{-10}}$ GeV$^{{-1}}$', fontsize=12)\n",
+    "    \n",
+    "    ax.legend(loc='upper right', fontsize=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf64f3c5-f1b6-4a46-a4ad-499bdb3da64c",
+   "metadata": {},
+   "source": [
+    "### Compare Baseline Model to 200 MeV ALP\n",
+    "\n",
+    "Show the spectra from the ALP model at several times. The baseline model (no ALP) spectra are drawn as dashed lines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84c54e19-8051-48f3-ba08-606013fd44b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nt = t.shape[0]\n",
+    "\n",
+    "fig, axes = plt.subplots(1,2, figsize=(10,4.5), sharex=True, tight_layout=True)\n",
+    "\n",
+    "fmin, fmax = 0, -1e99\n",
+    "\n",
+    "for fl in (Flavor.NU_E, Flavor.NU_E_BAR):\n",
+    "    ax = axes[fl]\n",
+    "\n",
+    "    for j in np.arange(nt):\n",
+    "        color = None\n",
+    "        for i, model in enumerate([model_std, models[(200*u.MeV,20e-10/u.GeV)]]):\n",
+    "            d2fdEdt = model.get_flux(t, E, d)\n",
+    "            dfdE = d2fdEdt.array[fl, j, :].to_value('1e12/(MeV s cm2)')\n",
+    "            fmax = np.maximum(fmax, np.max(dfdE))\n",
+    "            ls = '--' if i == 0 else '-'\n",
+    "            label = None if i == 0 else rf'$t_\\text{{pb}}={t[j].to_value(\"ms\"):g}$ ms'\n",
+    "            width = 1 if i==0 else 1.5\n",
+    "            line, = ax.plot(E, dfdE, label=label, ls=ls, lw=width, color=color)\n",
+    "            color = line.get_color()\n",
+    "\n",
+    "    ax.set(xlim=E[[0,-1]].to_value(),\n",
+    "           xlabel='energy [MeV]',\n",
+    "           ylim=(fmin, 1.1*fmax),\n",
+    "           ylabel=rf'$\\Phi_{{{fl.to_tex()[1:-1]}}}$ [$10^{{12}}$ MeV$^{{-1}}$ s$^{{-1}}$ m$^{{-2}}$]',\n",
+    "          )\n",
+    "    ax.set_title(rf'$m_a=\\text{{{model.metadata[\"Axion mass\"]}}}$, $g_{{a\\gamma}}={model.metadata[\"Axion coupling\"].to_value(\"1e-10/GeV\")}\\times10^{{-10}}$ GeV$^{{-1}}$', fontsize=12)\n",
+    "    \n",
+    "    ax.legend(loc='upper right', fontsize=10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/source/nb/ccsn/Takata_2025.ipynb
+++ b/doc/source/nb/ccsn/Takata_2025.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "29ceae1a",
    "metadata": {},
    "outputs": [],
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1b7566ed",
    "metadata": {},
    "outputs": [],
@@ -63,23 +63,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f62e690f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'progenitor_mass': <Quantity [11.2, 20. , 25. ] solMass>,\n",
-       " 'axion_mass': <Quantity [  0.,  40., 100., 150., 200., 300., 400., 600., 800.] MeV>,\n",
-       " 'axion_coupling': <Quantity [ 0.,  2.,  4.,  6.,  8., 10.] 1e-10 / GeV>}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Takata_2025.param"
    ]
@@ -96,27 +83,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "649f5ae4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "**Takata_2025 Model**: 25_000_00.dat\n"
-      ],
-      "text/plain": [
-       "Takata_2025 Model: 25_000_00.dat"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "model_std = Takata_2025(axion_mass=0, axion_coupling=0, progenitor_mass=25*u.Msun)\n",
-    "model_std"
+    "pmass = 25*u.Msun\n",
+    "model_std = Takata_2025(axion_mass=0, axion_coupling=0, progenitor_mass=pmass)\n",
+    "model_std.metadata"
    ]
   },
   {
@@ -128,8 +102,8 @@
    "source": [
     "# Initialize a handful of axion models.\n",
     "models = {}\n",
-    "for (am, ac) in ((100*u.MeV, 2e-10/u.GeV), (200*u.MeV,2e-10/u.GeV), (100*u.MeV,10e-10/u.GeV), (100*u.MeV,20e-10/u.GeV), (200*u.MeV,10e-10/u.GeV), (200*u.MeV,20e-10/u.GeV)):\n",
-    "    models[(am,ac)] = Mori_2023(axion_mass=am, axion_coupling=ac)\n",
+    "for (am, ac) in ((40*u.MeV, 4e-10/u.GeV), (100*u.MeV, 6e-10/u.GeV), (200*u.MeV, 6e-10/u.GeV), (300*u.MeV, 8e-10/u.GeV), (400*u.MeV, 10e-10/u.GeV), (600*u.MeV, 6e-10/u.GeV)):\n",
+    "    models[(am,ac)] = Takata_2025(axion_mass=am, axion_coupling=ac, progenitor_mass=pmass)\n",
     "\n",
     "models"
    ]
@@ -144,6 +118,16 @@
     "Compare axion model luminosity to the standard 2D simulation.\n",
     "\n",
     "Higher mass models with stronger coupling constants should produce a decrease in neutrino luminosity at all flavors relative to the reference simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a828245a-719a-4f56-a6ad-42d34b9bc18e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_std.metadata[\"Progenitor mass\"].to_value(\"Msun\")"
    ]
   },
   {
@@ -164,7 +148,7 @@
     "    for j, (flavor) in enumerate(Flavor):\n",
     "        ax = axes[0][j]\n",
     "        \n",
-    "        ax.plot(model_std.time, model_std.luminosity[flavor]/1e51, 'k', label=r'$20M_\\odot$ reference')  # Report luminosity in [foe/s]\n",
+    "        ax.plot(model_std.time, model_std.luminosity[flavor]/1e51, 'k', label=rf'${{{model_std.metadata[\"Progenitor mass\"].to_value(\"Msun\"):g}}}M_\\odot$ reference')  # Report luminosity in [foe/s]\n",
     "        Lmin = np.minimum(Lmin, np.min(model_std.luminosity[flavor].to_value('1e51 erg/s')))\n",
     "        Lmax = np.maximum(Lmax, np.max(model_std.luminosity[flavor].to_value('1e51 erg/s')))\n",
     "        \n",
@@ -228,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = np.arange(0.05, 0.3, 0.05) * u.s\n",
+    "t = np.arange(0.05, 0.35, 0.05) * u.s\n",
     "E = np.arange(0, 50.1, 0.1) * u.MeV\n",
     "d = 1*u.kpc"
    ]
@@ -261,7 +245,7 @@
     "\n",
     "    for j in np.arange(nt):\n",
     "        color = None\n",
-    "        for i, model in enumerate([model_std, models[(100*u.MeV,10e-10/u.GeV)]]):\n",
+    "        for i, model in enumerate([model_std, models[(100*u.MeV, 6e-10/u.GeV)]]):\n",
     "            d2fdEdt = model.get_flux(t, E, d)\n",
     "            dfdE = d2fdEdt.array[fl, j, :].to_value('1e12/(MeV s cm2)')\n",
     "            fmax = np.maximum(fmax, np.max(dfdE))\n",
@@ -286,7 +270,7 @@
    "id": "bf64f3c5-f1b6-4a46-a4ad-499bdb3da64c",
    "metadata": {},
    "source": [
-    "### Compare Baseline Model to 200 MeV ALP\n",
+    "### Compare Baseline Model to 400 MeV ALP\n",
     "\n",
     "Show the spectra from the ALP model at several times. The baseline model (no ALP) spectra are drawn as dashed lines."
    ]
@@ -309,7 +293,7 @@
     "\n",
     "    for j in np.arange(nt):\n",
     "        color = None\n",
-    "        for i, model in enumerate([model_std, models[(200*u.MeV,20e-10/u.GeV)]]):\n",
+    "        for i, model in enumerate([model_std, models[(400*u.MeV, 10e-10/u.GeV)]]):\n",
     "            d2fdEdt = model.get_flux(t, E, d)\n",
     "            dfdE = d2fdEdt.array[fl, j, :].to_value('1e12/(MeV s cm2)')\n",
     "            fmax = np.maximum(fmax, np.max(dfdE))\n",

--- a/python/snewpy/models/ccsn.py
+++ b/python/snewpy/models/ccsn.py
@@ -441,8 +441,6 @@ class Takata_2025(loaders.Takata_2025):
             else: 
                 filename = f'25_{axion_mass.to_value("MeV"):3g}_{axion_coupling.to_value("1e-10/GeV"):02g}.dat'
 
-        self.metadata = {}
-
         return super().__init__(filename, self.metadata)
 
 

--- a/python/snewpy/models/ccsn.py
+++ b/python/snewpy/models/ccsn.py
@@ -399,13 +399,13 @@ class Mori_2023(loaders.Mori_2023):
 @RegistryModel(
                _param_validator = lambda p: \
                (p['progenitor_mass'].to_value('Msun') in (11.2, 20, 25) and p['axion_mass'] == 0 and p['axion_coupling'] == 0) or \
-               (p['progenitor_mass'].to_value('Msun') in (11.2, 20, 25) and p['axion_mass'].to_value('MeV') in (40, 100, 150, 200, 300, 600, 400, 800) and p['axion_coupling'].to_value('1e-10/GeV') in (2, 4, 6, 8, 10)),
+               (p['progenitor_mass'].to_value('Msun') in (11.2, 20, 25) and p['axion_mass'].to_value('MeV') in (40, 100, 150, 200, 300, 600, 400, 800) and p['axion_coupling'].to_value('1e-10/GeV') in (4, 6, 8, 10)),
 
                progenitor_mass = Parameter(values=[11.2, 20, 25]<<u.Msun,
                                           description='Progenitor star mass in units of M☉'),
                axion_mass = Parameter(values=[0, 40, 100, 150, 200, 300, 400, 600, 800]<<u.MeV,
                                       description='Axion mass in units of MeV'),
-               axion_coupling = Parameter(values=[0, 2, 4, 6, 8, 10]<<(1e-10/u.GeV),
+               axion_coupling = Parameter(values=[0, 4, 6, 8, 10]<<(1e-10/u.GeV),
                                           description='Axion-photon coupling, in units of 1e-10/GeV',
                                           precision=2 #round to 1e-12/u.GeV
                                          )

--- a/python/snewpy/models/ccsn.py
+++ b/python/snewpy/models/ccsn.py
@@ -425,21 +425,11 @@ class Takata_2025(loaders.Takata_2025):
         # Make sure the axion coupling is converted to units 1e-10/GeV:
         # axion_coupling = np.round(axion_coupling.to('1e-10/GeV'))
 
+        pmass = f'{np.trunc(progenitor_mass.to_value("Msun")):g}'
         if axion_mass == 0:
-            if progenitor_mass == 11.2*u.Msun:
-                filename = '11_000_00.dat'
-            elif progenitor_mass == 20*u.Msun:
-                filename = '20_000_00.dat'
-            else: 
-                filename = '25_000_00.dat'
-
+            filename = f'{pmass}_000_00.dat'
         else:
-            if progenitor_mass == 11.2*u.Msun:
-                filename = f'11_{axion_mass.to_value("MeV"):3g}_{axion_coupling.to_value("1e-10/GeV"):02g}.dat'
-            elif progenitor_mass == 20*u.Msun:
-                filename = f'20_{axion_mass.to_value("MeV"):3g}_{axion_coupling.to_value("1e-10/GeV"):02g}.dat'
-            else: 
-                filename = f'25_{axion_mass.to_value("MeV"):3g}_{axion_coupling.to_value("1e-10/GeV"):02g}.dat'
+            filename = f'{pmass}_{axion_mass.to_value("MeV"):03g}_{axion_coupling.to_value("1e-10/GeV"):02g}.dat'
 
         return super().__init__(filename, self.metadata)
 

--- a/python/snewpy/models/ccsn_loaders.py
+++ b/python/snewpy/models/ccsn_loaders.py
@@ -941,13 +941,18 @@ class Takata_2025(PinchedModel):
 
         self.metadata = metadata
 
-        #Read ASCII data.
+        # Read ASCII data and clean up NaN values in float columns.
         simtab = Table.read(datafile, format='ascii')
+        has_nan = np.zeros(len(simtab), dtype=bool)
+        for col in simtab.itercols():
+            if col.info.dtype.kind == 'f':
+                has_nan |= np.isnan(col)
+        simtab = simtab[~has_nan]
 
-        #Remove the first table row, which appears to have zero input.
+        # Remove the first table row, which appears to have zero input.
         simtab = simtab[simtab['1:t_sim[s]'] > 0]
 
-        #Get grid of model times.
+        # Get grid of model times.
         simtab['TIME'] = simtab['2:t_pb[s]'] << u.s
         for j, (f, fkey) in enumerate(zip(["NU_E", "NU_E_BAR", "NU_X"], 'ebx')):
             simtab[f'L_{f}'] = simtab[f'{6+j}:Le{fkey}[e/s]'] << u.erg / u.s

--- a/python/snewpy/test/test_01_registry.py
+++ b/python/snewpy/test/test_01_registry.py
@@ -450,17 +450,20 @@ class TestModels(unittest.TestCase):
         Instantiate a set of 'Takata 2025' models
         """
         for pmass in [11.2, 20, 25] << u.Msun:
-            for amass in [40, 100, 150, 200, 300, 400, 600, 800] << u.MeV:
-                for ga in [4, 6, 8, 10] << 1e-10/u.GeV:
+            for amass in [0, 40, 100, 150, 200, 300, 400, 600, 800] << u.MeV:
+                for ga in [0, 4, 6, 8, 10] << 1e-10/u.GeV:
+                    if (amass.value == 0) != (ga.value == 0):
+                        continue
+
                     model = Takata_2025(progenitor_mass=pmass, axion_mass=amass, axion_coupling=ga)
 
-                self.assertEqual(model.metadata['Progenitor mass'], pmass)
-                self.assertEqual(model.metadata['Axion mass'], amass)
-                self.assertEqual(model.metadata['Axion coupling'], ga)
+                    self.assertEqual(model.metadata['Progenitor mass'], pmass)
+                    self.assertEqual(model.metadata['Axion mass'], amass)
+                    self.assertEqual(model.metadata['Axion coupling'], ga)
 
-                # Check that times are in proper units.
-                t = model.get_time()
-                self.assertTrue(t.unit, u.s)
+                    # Check that times are in proper units.
+                    t = model.get_time()
+                    self.assertTrue(t.unit, u.s)
 
-                # Check that we can compute flux dictionaries.
-                self.check_model_spectra(model)
+                    # Check that we can compute flux dictionaries.
+                    self.check_model_spectra(model)

--- a/python/snewpy/test/test_01_registry.py
+++ b/python/snewpy/test/test_01_registry.py
@@ -11,8 +11,9 @@ from snewpy.models.ccsn import Nakazato_2013, OConnor_2013, Tamborra_2014, \
                           Walk_2019, Fornax_2019, \
                           Fischer_2020, Kuroda_2020, Warren_2020, \
                           Bugli_2021, Fornax_2021, Zha_2021, \
-                          Fornax_2022, \
-                          Mori_2023, Fornax_2024
+                          Fornax_2022, Mori_2023, Fornax_2024, \
+                          Takata_2025
+
 from snewpy import flux
 
 from astropy import units as u
@@ -39,6 +40,7 @@ class TestModels(unittest.TestCase):
                   Fornax_2022,
                   Mori_2023,
                   Fornax_2024,
+                  Takata_2025,
                   ]
 
         for model in models:
@@ -442,3 +444,23 @@ class TestModels(unittest.TestCase):
 
             # Check that we can compute flux dictionaries.
             self.check_model_spectra(model)
+
+    def test_Takata_2025(self):
+        """
+        Instantiate a set of 'Takata 2025' models
+        """
+        for pmass in [11.2, 20, 25] << u.Msun:
+            for amass in [40, 100, 150, 200, 300, 400, 600, 800] << u.MeV:
+                for ga in [4, 6, 8, 10] << 1e-10/u.GeV:
+                    model = Takata_2025(progenitor_mass=pmass, axion_mass=amass, axion_coupling=ga)
+
+                self.assertEqual(model.metadata['Progenitor mass'], pmass)
+                self.assertEqual(model.metadata['Axion mass'], amass)
+                self.assertEqual(model.metadata['Axion coupling'], ga)
+
+                # Check that times are in proper units.
+                t = model.get_time()
+                self.assertTrue(t.unit, u.s)
+
+                # Check that we can compute flux dictionaries.
+                self.check_model_spectra(model)

--- a/python/snewpy/test/test_02_models.py
+++ b/python/snewpy/test/test_02_models.py
@@ -3,6 +3,8 @@
 """
 import unittest
 
+import numpy as np
+
 from snewpy.flavor import ThreeFlavor
 from snewpy import flux
 from snewpy.models.ccsn_loaders import Nakazato_2013, Tamborra_2014, OConnor_2013, OConnor_2015, \
@@ -10,7 +12,7 @@ from snewpy.models.ccsn_loaders import Nakazato_2013, Tamborra_2014, OConnor_201
                                   Walk_2019, Fornax_2019, Warren_2020, \
                                   Fischer_2020, Kuroda_2020, \
                                   Bugli_2021, Fornax_2021, Zha_2021, \
-                                  Fornax_2024
+                                  Fornax_2024, Takata_2025
 from astropy import units as u
 from snewpy import model_path
 import re
@@ -335,3 +337,31 @@ class TestModels(unittest.TestCase):
             self.assertTrue(t.unit, u.s)
 
             self.check_model_spectra(model)
+
+    def test_Takata_2025(self):
+        """
+        Instantiate a set of 'Takata 2025' models
+        """
+        for pmass in [11.2, 20, 25] << u.Msun:
+            for amass in [0, 40, 100, 150, 200, 300, 400, 600, 800] << u.MeV:
+                for ga in [0, 4, 6, 8, 10] << 1e-10/u.GeV:
+                    if (amass.value == 0) != (ga.value == 0):
+                        continue
+
+                    mfile = '_'.join([
+                        f'{np.trunc(pmass.to_value("Msun")):g}',
+                        f'{amass.to_value("MeV"):03g}',
+                        f'{ga.to_value("1e-10/GeV"):02g}.dat'])
+
+                    model = Takata_2025(os.path.join(model_path, 'Takata_2025', mfile), metadata={'Progenitor mass':pmass, 'Axion mass':amass, 'Axion coupling':ga})
+
+                    self.assertEqual(model.metadata['Progenitor mass'], pmass)
+                    self.assertEqual(model.metadata['Axion mass'], amass)
+                    self.assertEqual(model.metadata['Axion coupling'], ga)
+
+                    # Check that times are in proper units.
+                    t = model.get_time()
+                    self.assertTrue(t.unit, u.s)
+
+                    # Check that we can compute flux dictionaries.
+                    self.check_model_spectra(model)


### PR DESCRIPTION
This PR started as a small effort to create a notebook to document the `Takata_2025` ALP production models, but in the course of that, I discovered the model constructor was broken in several places, so those got fixed as well.